### PR TITLE
Fix readonly property error in threejs

### DIFF
--- a/geminidiagnostico.html
+++ b/geminidiagnostico.html
@@ -786,19 +786,29 @@
 
     <script>
         document.addEventListener('DOMContentLoaded', function() {
-            // === DEBUGGING CRÍTICO ===
-            console.log('🌐 DOM Cargado');
+            console.log('🌐 DOM Cargado - Inicializando elementos...');
+            
+            // INICIALIZACIÓN SEGURA DE VARIABLES DOM
+            vizContainer = document.getElementById('threejs-container');
+            matrixEffectEl = document.getElementById('matrix-effect');
+            criticalAlertEl = document.getElementById('critical-alert');
+            
+            // VERIFICACIÓN CRÍTICA
+            if (!vizContainer) {
+                console.error('❌ threejs-container no encontrado');
+                return;
+            }
+            
+            console.log('✅ Elementos DOM inicializados correctamente');
             console.log('📦 THREE disponible:', typeof THREE);
-            console.log('🎯 Container existe:', !!document.getElementById('threejs-container'));
             
             // Test inmediato de Three.js
             setTimeout(() => {
                 console.log('⏰ Después de timeout - THREE:', typeof THREE);
                 if (typeof THREE === 'undefined') {
                     console.error('❌ THREE.js NO SE CARGÓ');
-                    const container = document.getElementById('threejs-container');
-                    if (container) {
-                        container.innerHTML = '<div style="color: red; padding: 20px; text-align: center;">❌ CDN Three.js falló - Verificar conexión a internet</div>';
+                    if (vizContainer) {
+                        vizContainer.innerHTML = '<div style="color: red; padding: 20px; text-align: center;">❌ CDN Three.js falló - Verificar conexión a internet</div>';
                     }
                 } else {
                     console.log('✅ THREE.js cargado correctamente');
@@ -1089,95 +1099,121 @@
                 );
             }
             
-            // Three.js Visualization Logic
-            const vizContainer = document.getElementById('threejs-container');
-            const matrixEffectEl = document.getElementById('matrix-effect');
-            const criticalAlertEl = document.getElementById('critical-alert');
-            
-            // DEBUGGING DE ELEMENTOS CRÍTICOS
-            console.log('🔍 === VERIFICACIÓN DE ELEMENTOS ===');
-            console.log('📦 vizContainer encontrado:', !!vizContainer, vizContainer);
-            console.log('✨ matrixEffectEl encontrado:', !!matrixEffectEl, matrixEffectEl);
-            console.log('🚨 criticalAlertEl encontrado:', !!criticalAlertEl, criticalAlertEl);
-            let scene, camera, renderer, head, hotspotsGroup;
+            // Three.js Visualization Logic - Variables globales seguras
+            let vizContainer = null;
+            let matrixEffectEl = null;
+            let criticalAlertEl = null;
+            let scene = null;
+            let camera = null;
+            let renderer = null;
+            let head = null;
+            let hotspotsGroup = null;
             let currentView = 'rgb';
-            let animationFrameId;
+            let animationFrameId = null;
 
             function initThreeJS() {
-                console.log('🚀 === INICIANDO THREE.JS MODO EMERGENCIA ===');
+                console.log('🚀 === INICIANDO THREE.JS MODO SEGURO ===');
                 
-                if (typeof THREE === 'undefined') {
-                    console.error('❌ THREE.js NO DISPONIBLE');
-                    vizContainer.innerHTML = '<div style="color: red; text-align: center; padding: 40px;">THREE.js no cargó</div>';
-                    return;
-                }
-
-                // Limpiar container completamente
-                vizContainer.innerHTML = '';
-                
-                // Configuración forzada
-                scene = new THREE.Scene();
-                camera = new THREE.PerspectiveCamera(75, 16/9, 0.1, 1000);
-                camera.position.z = 4;
-                
-                // Renderer con configuración mínima
-                renderer = new THREE.WebGLRenderer();
-                renderer.setSize(640, 360); // Tamaño fijo para evitar problemas
-                renderer.setClearColor(0x222222);
-                vizContainer.appendChild(renderer.domElement);
-                
-                // Luz básica
-                const light = new THREE.DirectionalLight(0xffffff, 1);
-                light.position.set(0, 1, 1);
-                scene.add(light);
-                scene.add(new THREE.AmbientLight(0x404040, 0.5));
-                
-                // Cubo simple para test
-                const geometry = new THREE.BoxGeometry(1, 1, 1);
-                const material = new THREE.MeshLambertMaterial({ color: 0x04D9FF });
-                head = new THREE.Mesh(geometry, material);
-                scene.add(head);
-                
-                // Grupo para hotspots
-                hotspotsGroup = new THREE.Group();
-                head.add(hotspotsGroup);
-                
-                // Re-añadir overlays
-                const alertDiv = document.createElement('div');
-                alertDiv.id = 'critical-alert';
-                alertDiv.className = 'critical-alert';
-                vizContainer.appendChild(alertDiv);
-                
-                const matrixDiv = document.createElement('div');
-                matrixDiv.id = 'matrix-effect';
-                matrixDiv.className = 'matrix-effect';
-                vizContainer.appendChild(matrixDiv);
-                
-                // Actualizar referencias globales
-                criticalAlertEl = alertDiv;
-                matrixEffectEl = matrixDiv;
-                
-                // Animación simple
-                function simpleAnimate() {
-                    requestAnimationFrame(simpleAnimate);
-                    if (head) {
-                        head.rotation.x += 0.01;
-                        head.rotation.y += 0.01;
+                try {
+                    // VERIFICACIONES CRÍTICAS
+                    if (typeof THREE === 'undefined') {
+                        throw new Error('THREE.js no disponible');
                     }
-                    if (renderer) renderer.render(scene, camera);
+                    
+                    if (!vizContainer) {
+                        throw new Error('Container no disponible');
+                    }
+                    
+                    // LIMPIEZA TOTAL
+                    vizContainer.innerHTML = '';
+                    
+                    // CONFIGURACIÓN THREE.JS
+                    scene = new THREE.Scene();
+                    camera = new THREE.PerspectiveCamera(75, 16/9, 0.1, 1000);
+                    camera.position.z = 4;
+                    
+                    renderer = new THREE.WebGLRenderer({ antialias: true });
+                    renderer.setSize(vizContainer.clientWidth, vizContainer.clientHeight);
+                    renderer.setClearColor(0x222222);
+                    vizContainer.appendChild(renderer.domElement);
+                    
+                    // LUCES
+                    const light = new THREE.DirectionalLight(0xffffff, 1);
+                    light.position.set(0, 1, 1);
+                    scene.add(light);
+                    scene.add(new THREE.AmbientLight(0x404040, 0.5));
+                    
+                    // MODELO CABEZA (ESFERA)
+                    const geometry = new THREE.SphereGeometry(1.2, 32, 32);
+                    const material = new THREE.MeshStandardMaterial({ 
+                        color: 0xcccccc, 
+                        roughness: 0.6, 
+                        metalness: 0.3 
+                    });
+                    head = new THREE.Mesh(geometry, material);
+                    scene.add(head);
+                    
+                    // GRUPO HOTSPOTS
+                    hotspotsGroup = new THREE.Group();
+                    head.add(hotspotsGroup);
+                    
+                    // RECREAR OVERLAYS DINÁMICAMENTE
+                    const alertDiv = document.createElement('div');
+                    alertDiv.id = 'critical-alert-dynamic';
+                    alertDiv.className = 'critical-alert';
+                    alertDiv.textContent = 'Sistema 3D Inicializado';
+                    vizContainer.appendChild(alertDiv);
+                    
+                    const matrixDiv = document.createElement('div');
+                    matrixDiv.id = 'matrix-effect-dynamic';
+                    matrixDiv.className = 'matrix-effect';
+                    vizContainer.appendChild(matrixDiv);
+                    
+                    // ACTUALIZAR REFERENCIAS GLOBALES
+                    criticalAlertEl = alertDiv;
+                    matrixEffectEl = matrixDiv;
+                    
+                    // INICIAR ANIMACIÓN
+                    animate();
+                    
+                    console.log('✅ THREE.js inicializado correctamente');
+                    console.log('🎯 Modelo 3D creado: Esfera gris rotando');
+                    console.log('🚨 Elementos overlay recreados');
+                    
+                    return true;
+                    
+                } catch (error) {
+                    console.error('💥 Error en initThreeJS:', error);
+                    if (vizContainer) {
+                        vizContainer.innerHTML = `
+                            <div style="color: #F87171; text-align: center; padding: 40px;">
+                                ❌ Error de inicialización 3D<br>
+                                <small>${error.message}</small>
+                            </div>
+                        `;
+                    }
+                    return false;
                 }
-                simpleAnimate();
-                
-                console.log('✅ MODO EMERGENCIA ACTIVADO - CUBO AZUL DEBE SER VISIBLE');
             }
 
             function animate() {
-                animationFrameId = requestAnimationFrame(animate);
-                if (head) {
-                    head.rotation.y += 0.01; // Rotación más visible
+                if (!scene || !camera || !renderer) {
+                    console.warn('⚠️ Componentes Three.js no disponibles para animación');
+                    return;
                 }
-                if (renderer && scene && camera) {
+                
+                animationFrameId = requestAnimationFrame(animate);
+                
+                if (head) {
+                    head.rotation.y += 0.01;
+                    head.rotation.x += 0.005;
+                }
+                
+                try {
                     renderer.render(scene, camera);
+                } catch (error) {
+                    console.error('💥 Error en render:', error);
+                    cancelAnimationFrame(animationFrameId);
                 }
             }
             
@@ -1202,46 +1238,59 @@
                 });
             }
 
-            function switchToView(view, patient) {
+            function switchToView(view, patient = null) {
                 console.log(`🎯 Cambiando a vista: ${view}`);
-                currentView = view;
-                document.querySelectorAll('.view-btn').forEach(btn => btn.classList.remove('active'));
-                const currentBtn = document.querySelector(`.view-btn[data-view="${view}"]`);
-                if (currentBtn) currentBtn.classList.add('active');
-
-                if (!head) {
-                    console.warn('Head model not ready');
+                
+                // VERIFICACIÓN CRÍTICA
+                if (!head || !hotspotsGroup || !criticalAlertEl) {
+                    console.warn('⚠️ Elementos 3D no disponibles para cambio de vista');
                     return;
                 }
-
-                // LIMPIEZA CORRECTA DE HOTSPOTS
+                
+                currentView = view;
+                
+                // ACTUALIZAR BOTONES
+                document.querySelectorAll('.view-btn').forEach(btn => {
+                    btn.classList.remove('active');
+                });
+                const currentBtn = document.querySelector(`.view-btn[data-view="${view}"]`);
+                if (currentBtn) currentBtn.classList.add('active');
+                
+                // LIMPIAR HOTSPOTS
                 while(hotspotsGroup.children.length > 0) {
                     const child = hotspotsGroup.children[0];
                     hotspotsGroup.remove(child);
                     if(child.geometry) child.geometry.dispose();
                     if(child.material) child.material.dispose();
                 }
+                
+                // LIMPIAR ALERTA
                 criticalAlertEl.style.opacity = 0;
-
+                
                 switch(view) {
                     case 'rgb':
-                        head.material = new THREE.MeshStandardMaterial({ color: 0xcccccc, roughness: 0.6, metalness: 0.3 });
-                        head.material.wireframe = false;
+                        head.material = new THREE.MeshStandardMaterial({ 
+                            color: 0xcccccc, 
+                            roughness: 0.6, 
+                            metalness: 0.3,
+                            wireframe: false
+                        });
                         console.log('📷 Vista RGB activada');
                         break;
+                        
                     case 'thermal':
+                        // GENERAR TEXTURA TÉRMICA
                         const canvas = document.createElement('canvas');
                         canvas.width = 256;
                         canvas.height = 256;
                         const context = canvas.getContext('2d');
                         
-                        // Gradiente térmico más realista
                         const gradient = context.createRadialGradient(128, 128, 0, 128, 128, 128);
-                        gradient.addColorStop(0, '#ff0000');    // Rojo centro (caliente)
-                        gradient.addColorStop(0.3, '#ff8800');  // Naranja
-                        gradient.addColorStop(0.6, '#ffff00');  // Amarillo
-                        gradient.addColorStop(0.8, '#00ff00');  // Verde
-                        gradient.addColorStop(1, '#0088ff');    // Azul (frío)
+                        gradient.addColorStop(0, '#ff0000');
+                        gradient.addColorStop(0.3, '#ff8800');
+                        gradient.addColorStop(0.6, '#ffff00');
+                        gradient.addColorStop(0.8, '#00ff00');
+                        gradient.addColorStop(1, '#0088ff');
                         
                         context.fillStyle = gradient;
                         context.fillRect(0, 0, 256, 256);
@@ -1250,34 +1299,39 @@
                             map: new THREE.CanvasTexture(canvas),
                             wireframe: false
                         });
-                        console.log('🌡️ Vista térmica activada - Heat map aplicado');
+                        console.log('🌡️ Vista térmica activada');
                         break;
+                        
                     case 'fused':
-                        console.log('🔬 Activando vista fusión');
-                        head.material = new THREE.MeshStandardMaterial({ color: 0x04D9FF, roughness: 0.4, metalness: 0.5, wireframe: true });
-                        if (patient && patient.hotspots) {
+                        head.material = new THREE.MeshStandardMaterial({ 
+                            color: 0x04D9FF, 
+                            roughness: 0.4, 
+                            metalness: 0.5, 
+                            wireframe: true 
+                        });
+                        
+                        // AGREGAR HOTSPOTS SI DISPONIBLES
+                        if (patient && patient.hotspots && patient.hotspots.length > 0) {
                             patient.hotspots.forEach(spot => {
                                 const hotspotGeometry = new THREE.SphereGeometry(0.1, 16, 16);
-                                const hotspotMaterial = new THREE.MeshBasicMaterial({ color: 0xF87171, transparent: true, opacity: 0.8 });
+                                const hotspotMaterial = new THREE.MeshBasicMaterial({ 
+                                    color: 0xF87171, 
+                                    transparent: true, 
+                                    opacity: 0.8 
+                                });
                                 const hotspot = new THREE.Mesh(hotspotGeometry, hotspotMaterial);
-                                hotspot.position.set(spot.position.x, spot.position.y, spot.position.z).multiplyScalar(1.5);
+                                hotspot.position.set(spot.position.x, spot.position.y, spot.position.z);
+                                hotspot.position.multiplyScalar(1.5);
                                 hotspotsGroup.add(hotspot);
                                 
+                                // MOSTRAR ALERTA
                                 criticalAlertEl.textContent = spot.message;
                                 criticalAlertEl.style.opacity = 1;
                             });
-                        }
-                        
-                        // FORZAR ALERTA PARA TESTING
-                        const alertEl = document.getElementById('critical-alert');
-                        if (alertEl) {
-                            alertEl.textContent = 'ZONA DE PRUEBA DETECTADA - FUSIÓN IA ACTIVA';
-                            alertEl.style.opacity = 1;
-                            console.log('🚨 Alerta crítica activada - Texto:', alertEl.textContent);
-                            console.log('🎯 Alerta visible - Opacity:', alertEl.style.opacity);
                         } else {
-                            console.error('❌ Elemento critical-alert no encontrado en DOM');
-                            console.log('🔍 Elementos disponibles:', document.querySelectorAll('[id*="alert"]'));
+                            // ALERTA GENÉRICA PARA DEMO
+                            criticalAlertEl.textContent = 'ZONA DE PRUEBA DETECTADA - FUSIÓN IA ACTIVA';
+                            criticalAlertEl.style.opacity = 1;
                         }
                         
                         console.log('🔬 Vista fusión IA activada');
@@ -1400,28 +1454,14 @@
             const container = document.getElementById('threejs-container');
             container.innerHTML = '<div class="flex items-center justify-center h-full text-primary">🔄 Cargando visualización 3D...</div>';
             
-            // Aumentar timeout inicialización
+            // Inicialización segura del sistema 3D
             setTimeout(() => {
-                console.log('🚀 === INICIANDO SISTEMA 3D ===');
-                console.log('⏰ Timeout completado - Verificando dependencias...');
-                console.log('📦 THREE disponible:', typeof THREE !== 'undefined');
-                console.log('🎯 Container disponible:', !!document.getElementById('threejs-container'));
-                console.log('🚨 Alert element disponible:', !!document.getElementById('critical-alert'));
-                
-                if (typeof THREE !== 'undefined') {
-                    console.log('✅ Todas las dependencias OK - Iniciando sistema 3D...');
-                    try {
-                        initThreeJS();
-                        console.log('🎉 Sistema 3D inicializado exitosamente');
-                    } catch (error) {
-                        console.error('💥 Error al inicializar Three.js:', error);
-                        document.getElementById('threejs-container').innerHTML = 
-                            '<div class="flex items-center justify-center h-full text-red-400 p-4 text-center">💥 Error de inicialización 3D<br><small>' + error.message + '</small></div>';
-                    }
+                console.log('🚀 Iniciando sistema 3D...');
+                const success = initThreeJS();
+                if (success) {
+                    console.log('🎉 Sistema completamente funcional');
                 } else {
-                    console.error('❌ Three.js no disponible después de 1000ms');
-                    document.getElementById('threejs-container').innerHTML = 
-                        '<div class="flex items-center justify-center h-full text-red-400 p-4 text-center">❌ Error de carga 3D<br><small>Three.js no se cargó</small></div>';
+                    console.log('❌ Sistema 3D falló - Ver errores arriba');
                 }
             }, 1000);
         });


### PR DESCRIPTION
Fixes "Attempted to assign to readonly property" error in Three.js by refactoring global variable declarations and ensuring safe DOM and Three.js initialization.

The persistent error stemmed from `const` declarations for variables that were later reassigned, premature DOM access before `DOMContentLoaded`, and inconsistent element references within Three.js functions. This PR addresses these issues by using `let` for mutable globals, initializing DOM elements only after `DOMContentLoaded`, and adding robust checks and error handling to Three.js related functions.

---

[Open in Web](https://cursor.com/agents?id=bc-4d69742c-3257-4e7d-bf85-6ba1e90698cb) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-4d69742c-3257-4e7d-bf85-6ba1e90698cb) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)