### PR TITLE
Corregir declaración de variables globales en geminidiagnostico

### DIFF
--- a/geminidiagnostico.html
+++ b/geminidiagnostico.html
@@ -785,6 +785,18 @@
     </div>
 
     <script>
+        // === VARIABLES GLOBALES SEGURAS ===
+        let vizContainer = null;
+        let matrixEffectEl = null;
+        let criticalAlertEl = null;
+        let scene = null;
+        let camera = null;
+        let renderer = null;
+        let head = null;
+        let hotspotsGroup = null;
+        let currentView = 'rgb';
+        let animationFrameId = null;
+
         document.addEventListener('DOMContentLoaded', function() {
             console.log('🌐 DOM Cargado - Inicializando elementos...');
             
@@ -1099,17 +1111,7 @@
                 );
             }
             
-            // Three.js Visualization Logic - Variables globales seguras
-            let vizContainer = null;
-            let matrixEffectEl = null;
-            let criticalAlertEl = null;
-            let scene = null;
-            let camera = null;
-            let renderer = null;
-            let head = null;
-            let hotspotsGroup = null;
-            let currentView = 'rgb';
-            let animationFrameId = null;
+            // Three.js Visualization Logic - Variables ya declaradas globalmente
 
             function initThreeJS() {
                 console.log('🚀 === INICIANDO THREE.JS MODO SEGURO ===');


### PR DESCRIPTION
Move global JavaScript variable declarations to the script's top level to fix "readonly property" errors.

The previous setup declared variables either implicitly or within the `DOMContentLoaded` scope, leading to "Attempted to assign to readonly property" errors when attempting to reassign them. This change ensures variables are declared once with `let` in the global scope, allowing for correct initialization and preventing the error, which makes the Three.js visualization functional.

---

[Open in Web](https://cursor.com/agents?id=bc-67baef76-f61b-4649-8260-9800200b5bf0) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-67baef76-f61b-4649-8260-9800200b5bf0) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)