### PR TITLE
Diagnose and fix rendering issue in geminidiagnostico.html

### DIFF
--- a/geminidiagnostico.html
+++ b/geminidiagnostico.html
@@ -59,6 +59,18 @@
         .ring-primary { --tw-ring-color: var(--primary-blue); }
         .text-accent { color: var(--accent-green); }
         .bg-accent { background-color: var(--accent-green); }
+        
+        /* Custom utility classes for surface colors and text */
+        .bg-surface-dark { background-color: var(--surface-dark); }
+        .bg-surface-light { background-color: var(--surface-light); }
+        .text-text-muted { color: var(--text-muted); }
+        .text-text-light { color: var(--text-light); }
+        .text-bg-dark { color: var(--bg-dark); }
+        .border-border-color { border-color: var(--border-color); }
+        .border-accent { border-color: var(--accent-green); }
+        .border-surface-dark { border-color: var(--surface-dark); }
+        .bg-border-color { background-color: var(--border-color); }
+        .hover\:border-primary:hover { border-color: var(--primary-blue); }
 
         .btn-primary {
             background-color: var(--primary-blue);


### PR DESCRIPTION
Add missing custom CSS utility classes to render all sections of `geminidiagnostico.html`.

The sections were not visible because the HTML used custom Tailwind-like classes (e.g., `bg-surface-dark`) that referenced CSS variables but were not defined as actual utility classes in the embedded stylesheet. Adding these definitions resolves the rendering issue.

---

[Open in Web](https://cursor.com/agents?id=bc-c4cf2f4c-2d87-4f54-98e0-b98997f0426c) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-c4cf2f4c-2d87-4f54-98e0-b98997f0426c) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)