### PR TITLE
Follow-up: wire signal_detector recuperado al lazo proactivo

### DIFF
--- a/rag-bot/action_handler.py
+++ b/rag-bot/action_handler.py
@@ -170,6 +170,7 @@ def _compute_resume_message(last_active_at: Optional[str], phase: Optional[str] 
 # ------------------------------------------------------------------
 
 _SIGNAL_TO_ACTION: Dict[str, str] = {
+    "no_activity_7d": "reengage",
     "no_activity_72h": "reengage",
     "stalled_onboarding": "tally_reminder",
     "low_progress": "checkin",
@@ -216,6 +217,7 @@ def generate_action_for_signal(
     """
     action_type = _SIGNAL_TO_ACTION.get(signal.signal_type, "checkin")
     base = {
+        "no_activity_7d": "Han pasado varios días. Aquí seguimos contigo — ¿retomamos tu protocolo con un primer paso simple?",
         "no_activity_72h": "Hola, hace tiempo que no tenemos actividad. ¿Quieres retomar?",
         "stalled_onboarding": "Recuerda completar el Tally de síntomas cuando puedas.",
         "low_progress": "Check-in rápido: ¿cómo vas con el protocolo esta semana?",

--- a/rag-bot/proactive_scan.py
+++ b/rag-bot/proactive_scan.py
@@ -1,0 +1,68 @@
+"""
+proactive_scan.py — Wiring layer: signal_detector (ver) -> action_handler (decidir).
+
+Bridges the two BetaSignal shapes:
+  signal_detector.BetaSignal(beta_id, signal_type, severity, context, detected_at)
+    -> action_handler.BetaSignal(beta_id, signal_type, phase, last_active_at, metadata)
+
+then runs generate_and_persist_for_signal for each (C1-protected persist + dry-run
+execute). This replaces hand-injected signals: the proactive loop now derives its
+input from the detector over hv_beta_states (postgres SSOT) or file states.
+
+CLI:
+  python rag-bot/proactive_scan.py            # scan + persist + dry-run execute
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+ROOT = Path(__file__).resolve().parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from signal_detector import BetaSignalDetector, BetaSignal as DetectorSignal  # type: ignore
+from action_handler import BetaSignal as ActionSignal, generate_and_persist_for_signal  # type: ignore
+
+
+def adapt(sig: "DetectorSignal") -> ActionSignal:
+    """Detector signal -> action_handler signal (carries phase + last_active_at + severity)."""
+    ctx = dict(sig.context or {})
+    return ActionSignal(
+        beta_id=sig.beta_id,
+        signal_type=sig.signal_type,
+        phase=ctx.get("phase"),
+        last_active_at=ctx.get("last_active_at"),
+        metadata={**ctx, "severity": sig.severity, "detected_at": sig.detected_at},
+    )
+
+
+def scan_and_generate(
+    states: Optional[List[Dict[str, Any]]] = None,
+    *,
+    dry_run: bool = True,
+) -> List[Dict[str, Any]]:
+    """Detect signals, adapt, and generate+persist (dry-run execute by default)."""
+    detector = BetaSignalDetector()
+    signals = detector.scan(states)
+    results: List[Dict[str, Any]] = []
+    for sig in signals:
+        results.append(generate_and_persist_for_signal(adapt(sig), dry_run=dry_run))
+    return results
+
+
+def main(argv: Optional[list] = None) -> int:
+    results = scan_and_generate(dry_run=True)
+    by_type: Dict[str, int] = {}
+    for r in results:
+        at = (r.get("action") or {}).get("action_type", "unknown")
+        by_type[at] = by_type.get(at, 0) + 1
+    print(f"[proactive-scan] {len(results)} signal(s) -> actions: "
+          f"{json.dumps(by_type, ensure_ascii=False)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/rag-bot/signal_detector.py
+++ b/rag-bot/signal_detector.py
@@ -1,0 +1,129 @@
+"""
+signal_detector.py — Capa 6 de la Guía Agéntica Estándar: separa "ver" de "decidir".
+
+Emite BetaSignal a partir del estado de cada beta; un handler (action_handler) decide
+la acción. Señales y umbrales (verbatim del diseño original, ver recovered/README.md):
+- no_activity_7d        inactividad > 168h            (high)
+- no_activity_72h       inactividad > 72h             (medium)
+- stalled_onboarding    onboarding, sin tally, > 120h (high)
+- low_progress          <40% de slots y > 240h        (medium)
+- missing_labs          tally hecho, labs no, > 96h   (medium)
+
+LIVE/WIRED version. The faithful bytecode reconstruction lives in
+recovered/signal_detector.py. The only delta here vs that archive: each signal's
+`context` carries `last_active_at` so it can bridge to action_handler.BetaSignal
+(which uses it for the TRAJ-HV-010 resume bands). Thresholds/types are unchanged.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+try:
+    from state_persistence import list_all_betas as _list_all_betas  # type: ignore
+except Exception:
+    try:
+        from state_persistence import scan_all_states as _list_all_betas  # type: ignore
+    except Exception:
+        _list_all_betas = None  # type: ignore
+
+
+def _utc_now():
+    return datetime.now(timezone.utc)
+
+
+def _hours_since(ts: Optional[str]) -> Optional[float]:
+    if not ts:
+        return None
+    try:
+        if ts.endswith("Z"):
+            ts = ts[:-1] + "+00:00"
+        last = datetime.fromisoformat(ts)
+        return (_utc_now() - last).total_seconds() / 3600
+    except Exception:
+        return None
+
+
+class BetaSignal:
+    def __init__(self, beta_id: str, signal_type: str, severity: str = "medium",
+                 context: Optional[Dict] = None):
+        self.beta_id = beta_id
+        self.signal_type = signal_type
+        self.severity = severity
+        self.context = context or {}
+        self.detected_at = _utc_now().isoformat()
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "beta_id": self.beta_id,
+            "signal_type": self.signal_type,
+            "severity": self.severity,
+            "context": self.context,
+            "detected_at": self.detected_at,
+        }
+
+
+class BetaSignalDetector:
+    def __init__(self, states_dir: Optional[str] = None):
+        self.states_dir = states_dir
+
+    def _load_all_betas(self) -> List[Dict[str, Any]]:
+        if _list_all_betas is None:
+            return []
+        try:
+            return _list_all_betas()
+        except Exception as e:
+            print(f"[signal_detector] WARN: list_all_betas failed: {e}")
+            return []
+
+    def scan(self, states: Optional[List[Dict[str, Any]]] = None) -> List[BetaSignal]:
+        """Escanea betas y emite señales. `states` opcional (tests/calibración)."""
+        signals: List[BetaSignal] = []
+        betas = states if states is not None else self._load_all_betas()
+        for state in betas:
+            beta_id = state.get("beta_id") or "unknown"
+            phase = state.get("phase", "unknown")
+            slots = state.get("slots", {}) or {}
+            la = state.get("last_active_at")
+            hours = _hours_since(la)
+
+            def ctx(**extra: Any) -> Dict[str, Any]:
+                # last_active_at always carried for the action_handler bridge.
+                return {"last_active_at": la, "phase": phase, **extra}
+
+            if hours is not None:
+                if hours > 168:
+                    signals.append(BetaSignal(beta_id, "no_activity_7d", "high",
+                                              ctx(hours=round(hours, 1))))
+                elif hours > 72:
+                    signals.append(BetaSignal(beta_id, "no_activity_72h", "medium",
+                                              ctx(hours=round(hours, 1))))
+
+            if phase == "onboarding" and not slots.get("tally_completo"):
+                if hours is not None and hours > 120:
+                    signals.append(BetaSignal(beta_id, "stalled_onboarding", "high",
+                                              ctx(hours=round(hours, 1))))
+
+            completed = sum(1 for v in slots.values() if v)
+            total = len(slots) or 1
+            progress = completed / total
+            if progress < 0.4:
+                if hours is not None and hours > 240:
+                    signals.append(BetaSignal(beta_id, "low_progress", "medium",
+                                              ctx(progress=round(progress, 2))))
+
+            if slots.get("tally_completo") and not slots.get("labs_parseados"):
+                if hours is not None and hours > 96:
+                    signals.append(BetaSignal(beta_id, "missing_labs", "medium",
+                                              ctx(hours=round(hours, 1))))
+        return signals
+
+
+def _suggest_action(signal: "BetaSignal") -> str:
+    return {
+        "no_activity_7d": "Enviar recordatorio suave + oferta de ayuda / reenganche",
+        "no_activity_72h": "Mensaje de reingreso (usar ReentryHandler) + pregunta simple",
+        "stalled_onboarding": "Recordatorio específico de Tally + link directo",
+        "low_progress": "Check-in motivacional + revisión de slots pendientes",
+        "missing_labs": "Recordatorio de labs + instrucciones simplificadas",
+    }.get(signal.signal_type, "Revisar manualmente")

--- a/rag-bot/test_beta_state.py
+++ b/rag-bot/test_beta_state.py
@@ -190,5 +190,51 @@ class TestRagRetrievalLocal(unittest.TestCase):
         self.assertTrue(res.get("answer"))
 
 
+class TestSignalDetectorWiring(unittest.TestCase):
+    """Follow-up: signal_detector -> action_handler bridge (incl. no_activity_7d)."""
+
+    def _ago(self, hours):
+        from datetime import datetime, timezone, timedelta
+        return (datetime.now(timezone.utc) - timedelta(hours=hours)).isoformat()
+
+    def test_no_activity_7d_maps_to_reengage(self):
+        from action_handler import _SIGNAL_TO_ACTION, BetaSignal, generate_action_for_signal
+        self.assertEqual(_SIGNAL_TO_ACTION.get("no_activity_7d"), "reengage")
+        a = generate_action_for_signal(BetaSignal(beta_id="b", signal_type="no_activity_7d",
+                                                   phase="followup", last_active_at=self._ago(200)))
+        self.assertEqual(a["action_type"], "reengage")
+        self.assertTrue(a["suggested_message"])
+
+    def test_detector_emits_expected_signal_types(self):
+        from signal_detector import BetaSignalDetector
+        states = [
+            {"beta_id": "b7d", "phase": "followup", "last_active_at": self._ago(200), "slots": {"a": 1}},
+            {"beta_id": "bonb", "phase": "onboarding", "last_active_at": self._ago(130), "slots": {}},
+            {"beta_id": "blabs", "phase": "labs", "last_active_at": self._ago(100),
+             "slots": {"tally_completo": 1}},
+        ]
+        types = {s.signal_type for s in BetaSignalDetector().scan(states)}
+        self.assertIn("no_activity_7d", types)
+        self.assertIn("stalled_onboarding", types)
+        self.assertIn("missing_labs", types)
+
+    def test_scan_and_generate_end_to_end(self):
+        with tempfile.TemporaryDirectory() as td:
+            os.environ["HV_STATE_PERSISTENCE"] = "files"
+            os.environ["HV_PENDING_ACTIONS_DIR"] = td
+            os.environ["HV_TRACES_DIR"] = td
+            import proactive_scan
+            states = [{"beta_id": "bz", "phase": "followup",
+                       "last_active_at": self._ago(200), "slots": {"a": 1}}]
+            results = proactive_scan.scan_and_generate(states, dry_run=True)
+            self.assertEqual(len(results), 1)
+            action = results[0]["action"]
+            self.assertEqual(action["signal_type"], "no_activity_7d")
+            self.assertEqual(action["action_type"], "reengage")
+            # last_active_at bridged -> TRAJ-HV-010 resume context populated.
+            self.assertTrue(action.get("resume_context"))
+            self.assertEqual(results[0]["result"]["status"], "dry_run_executed")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Apila sobre #29. Cablea el `signal_detector` recuperado (de #29) al lazo proactivo, que antes consumía señales inyectadas a mano. **10 tests verdes**, golden 4/4.

## Cambios
- **`signal_detector.py`** (live): versión cableada del detector. `recovered/signal_detector.py` queda como archivo fiel. Único delta: cada `context` de señal lleva `last_active_at` para el puente. Importa `state_persistence.list_all_betas` (ya existía, L297 — no hizo falta alias).
- **`action_handler`**: `no_activity_7d → reengage` + su template. Era la señal de mayor severidad del detector y **no estaba mapeada** → caía al default `checkin`. Hallazgo de la recuperación en #29.
- **`proactive_scan.py`**: puente `signal_detector.BetaSignal → action_handler.BetaSignal` + `generate_and_persist_for_signal` (persist C1 + execute dry-run). CLI.

## Tests (+3)
- `no_activity_7d → reengage`
- el detector emite los tipos esperados (incl. `no_activity_7d`, `stalled_onboarding`, `missing_labs`)
- `scan_and_generate` end-to-end: verifica que `last_active_at`+`phase` cruzan el puente y disparan el `resume_context` (bandas TRAJ-HV-010)

## Nota de merge
Base = `close-gaps-g1-g7` para mostrar diff limpio sobre #29. Mergear **después** de #29 (o cambiar la base a `rag-bot/baseline` una vez #29 esté integrado).

🤖 Generated with [Claude Code](https://claude.com/claude-code)