### PR TITLE
ci: wire previously-unrun tests into CI (coverage gap)

### DIFF
--- a/.github/workflows/rag-bot-ci.yml
+++ b/.github/workflows/rag-bot-ci.yml
@@ -42,6 +42,19 @@ jobs:
           python test_rag_local.py
           python test_observability.py
 
+      - name: Extended unit suites (no API key needed)
+        # Previously these existed but no CI ran them. config/frozen_context/mvp0_lib/
+        # beta_state are pure unit; api_rag/newsletter_approval use FastAPI TestClient
+        # (no real OpenAI/Resend calls). Trajectory + test_rag (live retrieval) run in nightly.
+        run: |
+          python -m pytest -q -p no:cacheprovider \
+            test_config.py \
+            test_frozen_context.py \
+            test_mvp0_lib.py \
+            test_beta_state.py \
+            test_api_rag.py \
+            test_newsletter_approval.py
+
       - name: Golden set (gates-only)
         run: python golden_runner.py --gates-only
 

--- a/.github/workflows/rag-bot-ci.yml
+++ b/.github/workflows/rag-bot-ci.yml
@@ -98,14 +98,16 @@ jobs:
           from pathlib import Path
           from action_handler import compute_proactive_health_score
           hs = compute_proactive_health_score()
-          print(f"CI Proactive Health: score={hs[\"score\"]} is_healthy={hs.get(\"is_healthy\")}")
+          score = hs["score"]
+          is_healthy = hs.get("is_healthy")
+          print(f"CI Proactive Health: score={score} is_healthy={is_healthy}")
           cal_path = Path("data/proactive_calibration.json")
           drift = {}
           if cal_path.exists():
               cal = json.loads(cal_path.read_text())
               drift = cal.get("drift", {})
           print("CI Calibration drift:", {k: drift.get(k) for k in ["added", "removed", "message_changes", "significant_message_drift", "avg_message_similarity"] if k in drift})
-          if hs["score"] < 50:
+          if score < 50:
               print("::error::Proactive health score too low in CI (self-correction gate)")
               exit(1)
           if drift.get("significant_message_drift", 0) > 3:

--- a/.github/workflows/rag-bot-nightly.yml
+++ b/.github/workflows/rag-bot-nightly.yml
@@ -58,6 +58,17 @@ jobs:
           HV_DECISION_LOG_ENABLED: 'false'
         run: python golden_runner.py --full
 
+      - name: Trajectory integration tests (live retrieval)
+        # Need the embeddings index (built above) + OpenAI embeddings, so they belong
+        # here (key present) rather than the per-PR gate. Previously unran by any CI.
+        # NOTE: test_rag.py is intentionally excluded — it exercises the legacy Pinecone
+        # path (rag_retrieval.py needs pinecone-client + rich + a Pinecone key); the
+        # canonical retrieval is covered by test_rag_local.py + golden_runner.
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          HV_DECISION_LOG_ENABLED: 'false'
+        run: python -m pytest -q -p no:cacheprovider test_trajectory_runner.py
+
       - name: Upload embeddings artifact (debug)
         if: failure()
         uses: actions/upload-artifact@v4

--- a/rag-bot/requirements-rag-ci.txt
+++ b/rag-bot/requirements-rag-ci.txt
@@ -1,2 +1,8 @@
 # Minimal deps for rag-bot CI (gates-only + unit tests)
+# No API keys needed: these cover the no-network unit suites
+# (config/frozen_context/mvp0_lib/beta_state) + the FastAPI route tests
+# (api_rag/newsletter_approval, which use TestClient without real keys).
 python-dotenv>=1.0.0
+pytest>=8.0
+fastapi>=0.110
+httpx>=0.27


### PR DESCRIPTION
Reemplaza al #34 (cerrado automáticamente al borrarse su rama base #32 tras el merge). Ahora apunta directo a `main` (que ya incluye el fix `6/6→count-agnostic` de #32).

Cierra el gap de cobertura: de **11 archivos de test, solo 4 corrían en CI**.

- **`rag-bot-ci.yml`** (gate por-PR, sin secrets): +`test_config`, `test_frozen_context`, `test_mvp0_lib`, `test_beta_state` (unit puro) y `test_api_rag`, `test_newsletter_approval` (FastAPI TestClient, sin keys). +`pytest`/`fastapi`/`httpx` en `requirements-rag-ci.txt`.
- **`rag-bot-nightly.yml`** (ya tiene `OPENAI_API_KEY`): +`test_trajectory_runner` (retrieval en vivo).

Verificado local: gate de 6 tests **34 passed**; trajectory **7/7** con key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)