### PR TITLE
feat(proactive): C1 idempotency for pending actions (closes #31)

### DIFF
--- a/.github/workflows/rag-bot-ci.yml
+++ b/.github/workflows/rag-bot-ci.yml
@@ -53,7 +53,8 @@ jobs:
             test_mvp0_lib.py \
             test_beta_state.py \
             test_api_rag.py \
-            test_newsletter_approval.py
+            test_newsletter_approval.py \
+            test_c1_idempotency.py
 
       - name: Golden set (gates-only)
         run: python golden_runner.py --gates-only

--- a/rag-bot/action_handler.py
+++ b/rag-bot/action_handler.py
@@ -98,8 +98,15 @@ def generate_action_for_signal(signal: BetaSignal) -> Dict[str, Any]:
     else:
         suggested_message = f"Signal {signal.signal_type} detectado en {phase}. Acción recomendada: {next_action}"
 
+    # C1 idempotency: stable key (no per-second timestamp) so the same logical
+    # signal in the same hour-bucket collapses to one persisted/executed action,
+    # even if the cron and a manual run fire concurrently.
+    hour_bucket = datetime.now(timezone.utc).strftime("%Y%m%d%H")
+    idemp_key = f"{beta_id}:{signal.signal_type}:{phase}:{hour_bucket}"
+
     action = {
         "action_id": f"act-{beta_id}-{signal.signal_type}-{int(datetime.now().timestamp())}",
+        "idemp_key": idemp_key,
         "beta_id": beta_id,
         "signal": signal.to_dict(),
         "action_type": action_type,
@@ -114,8 +121,88 @@ def generate_action_for_signal(signal: BetaSignal) -> Dict[str, Any]:
     return action
 
 
+def _idemp_seen_in_files(idemp_key: str) -> bool:
+    """True si el idemp_key ya está en pending o executed (dedup file-mode, C1)."""
+    if not idemp_key:
+        return False
+    for path in (_pending_actions_path(), _executed_actions_path()):
+        if not path.exists():
+            continue
+        try:
+            with path.open(encoding="utf-8") as f:
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        if json.loads(line).get("idemp_key") == idemp_key:
+                            return True
+                    except Exception:
+                        continue
+        except Exception:
+            continue
+    return False
+
+
+def is_idemp_already_executed(idemp_key: str) -> bool:
+    """
+    C1: ¿este idemp_key ya se ejecutó? Postgres ledger primero (cuando aplica),
+    fallback al executed_actions.jsonl. Usado antes de cualquier side-effect.
+    """
+    if not idemp_key:
+        return False
+    try:
+        from state_persistence import is_idemp_executed_pg, pending_pg_enabled
+        if pending_pg_enabled():
+            return is_idemp_executed_pg(idemp_key)
+    except Exception as e:
+        print(f"[action_handler][warn] pg idemp check failed (fallback to files): {e}")
+    exec_path = _executed_actions_path()
+    if not exec_path.exists():
+        return False
+    try:
+        with exec_path.open(encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    rec = json.loads(line)
+                    if rec.get("idemp_key") == idemp_key and rec.get("status") in ("executed", "dry_run_executed"):
+                        return True
+                except Exception:
+                    continue
+    except Exception:
+        pass
+    return False
+
+
 def persist_pending_action(action: Dict[str, Any]) -> None:
-    """Append to a simple JSONL for consumption by future execution layer."""
+    """
+    Persiste una acción pendiente de forma IDEMPOTENTE (C1).
+    - Postgres (ledger): INSERT ... ON CONFLICT (idemp_key) DO NOTHING → dedup atómico
+      cross-process. Si hubo conflicto (ya existía), no se re-escribe el JSONL.
+    - Files: dedup por idemp_key contra pending+executed antes de hacer append.
+    El JSONL sigue siendo el store operativo (load/execute lo leen).
+    """
+    idemp_key = action.get("idemp_key")
+
+    pg_inserted: Optional[bool] = None
+    if idemp_key:
+        try:
+            from state_persistence import persist_pending_action_pg, pending_pg_enabled
+            if pending_pg_enabled():
+                pg_inserted = persist_pending_action_pg(action)
+        except Exception as e:
+            print(f"[action_handler][warn] pg persist_pending failed (fallback to files): {e}")
+
+    # Conflicto en el ledger → ya existía: no duplicar en archivo.
+    if pg_inserted is False:
+        return
+    # Sin ledger PG: dedup por archivo.
+    if pg_inserted is None and idemp_key and _idemp_seen_in_files(idemp_key):
+        return
+
     path = _pending_actions_path()
     with path.open("a", encoding="utf-8") as f:
         f.write(json.dumps(action, ensure_ascii=False) + "\n")
@@ -610,6 +697,16 @@ def execute_pending_action(action: Dict[str, Any], *, dry_run: bool = False, for
     if action.get("status") != "pending":
         return action
 
+    # === C1 idempotency: short-circuit if this logical action already executed ===
+    # Protects against double-send when cron + manual run (or run_detect_and_act twice)
+    # produce the same idemp_key. No side effects, no re-mark.
+    idemp_key = action.get("idemp_key")
+    if idemp_key and is_idemp_already_executed(idemp_key):
+        out = dict(action)
+        out["status"] = "already_executed"
+        out["idemp_key"] = idemp_key
+        return out
+
     beta_id = action["beta_id"]
     message = action.get("suggested_message", "")
 
@@ -712,6 +809,17 @@ def execute_pending_action(action: Dict[str, Any], *, dry_run: bool = False, for
     exec_path = _executed_actions_path()
     with exec_path.open("a", encoding="utf-8") as f:
         f.write(json.dumps(action, ensure_ascii=False) + "\n")
+
+    # C1: mark in the Postgres ledger too (best-effort) so is_idemp_already_executed
+    # is authoritative across processes when SSOT=postgres.
+    _ik = action.get("idemp_key")
+    if _ik:
+        try:
+            from state_persistence import mark_pending_executed_pg, pending_pg_enabled
+            if pending_pg_enabled():
+                mark_pending_executed_pg(_ik, dry_run=dry_run)
+        except Exception as e:
+            print(f"[action_handler][warn] pg mark_executed failed (file log still authoritative): {e}")
 
     # Remove from pending (rewrite pending file without this one)
     # Only remove on successful real or dry execution. Blocked actions stay in pending.

--- a/rag-bot/migrations/003_hv_pending_actions.down.sql
+++ b/rag-bot/migrations/003_hv_pending_actions.down.sql
@@ -1,0 +1,11 @@
+-- Rollback de 003_hv_pending_actions.sql
+-- Siguiendo el patrón del documento: .down.sql explícito
+
+BEGIN;
+
+DROP INDEX IF EXISTS idx_hv_pending_actions_beta_status;
+DROP INDEX IF EXISTS idx_hv_pending_actions_idemp_status;
+
+DROP TABLE IF EXISTS hv_pending_actions;
+
+COMMIT;

--- a/rag-bot/migrations/003_hv_pending_actions.sql
+++ b/rag-bot/migrations/003_hv_pending_actions.sql
@@ -1,0 +1,34 @@
+-- HV Pending Actions — Idempotencia C1 (Guía: acciones proactivas exactly-once)
+-- Ledger atómico de acciones proactivas para deduplicación fuerte cuando
+-- HV_STATE_PERSISTENCE=postgres|dual. El UNIQUE en idemp_key previene doble
+-- persist/ejecución incluso si el cron y un run manual corren a la vez.
+-- El store operativo sigue siendo el JSONL (load/execute); esta tabla es el
+-- ledger de idempotencia (persist = INSERT ON CONFLICT, execute = is_idemp + mark).
+--
+-- Siguiendo el patrón de 001/002: BEGIN/COMMIT + IF NOT EXISTS (idempotente),
+-- prefijo hv_* para aislamiento en el mismo Neon.
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS hv_pending_actions (
+  id                BIGSERIAL PRIMARY KEY,
+  beta_id           TEXT NOT NULL,
+  action_id         TEXT,
+  idemp_key         TEXT NOT NULL UNIQUE,            -- C1: beta:signal:phase:hour_bucket
+  signal_type       TEXT,
+  action_type       TEXT,
+  suggested_message TEXT,
+  status            TEXT NOT NULL DEFAULT 'pending', -- pending | executed | dry_run_executed | blocked_*
+  created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  executed_at       TIMESTAMPTZ,
+  metadata          JSONB NOT NULL DEFAULT '{}'::jsonb
+);
+
+-- Lookup por idempotencia (el UNIQUE ya crea índice, pero lo dejamos explícito por status).
+CREATE INDEX IF NOT EXISTS idx_hv_pending_actions_idemp_status
+  ON hv_pending_actions (idemp_key, status);
+-- Cola por beta + estado.
+CREATE INDEX IF NOT EXISTS idx_hv_pending_actions_beta_status
+  ON hv_pending_actions (beta_id, status, created_at DESC);
+
+COMMIT;

--- a/rag-bot/state_persistence.py
+++ b/rag-bot/state_persistence.py
@@ -391,3 +391,77 @@ def list_all_betas() -> List[Dict[str, Any]]:
         pass
 
     return betas
+
+
+# ------------------------------------------------------------------
+# Pending Actions — Idempotencia C1 (ledger Postgres, UNIQUE idemp_key)
+# ------------------------------------------------------------------
+# El store operativo de pending/executed sigue siendo el JSONL en action_handler.
+# Esta tabla (hv_pending_actions, migración 003) es un LEDGER de idempotencia:
+# - persist  -> INSERT ... ON CONFLICT (idemp_key) DO NOTHING  (dedup atómico cross-process)
+# - execute  -> is_idemp_executed_pg (chequeo) + mark_pending_executed_pg (status)
+# Best-effort: si Postgres no está, action_handler cae al dedup por archivo.
+
+def pending_pg_enabled() -> bool:
+    """True si debemos usar el ledger Postgres para idempotencia de pending actions."""
+    return _persistence_mode() in ("postgres", "dual") and bool(_get_database_url())
+
+
+def persist_pending_action_pg(action: Dict[str, Any]) -> bool:
+    """
+    Inserta la acción en el ledger. Devuelve True si fue NUEVA (insertada),
+    False si ya existía (conflicto por idemp_key) → el caller debe no re-persistir.
+    """
+    sql = """
+        INSERT INTO hv_pending_actions
+            (beta_id, action_id, idemp_key, signal_type, action_type,
+             suggested_message, status, created_at, metadata)
+        VALUES (%s, %s, %s, %s, %s, %s, %s, NOW(), %s)
+        ON CONFLICT (idemp_key) DO NOTHING
+        RETURNING id
+    """
+    params = (
+        action.get("beta_id"),
+        action.get("action_id"),
+        action.get("idemp_key"),
+        (action.get("signal") or {}).get("signal_type") or action.get("signal_type"),
+        action.get("action_type"),
+        action.get("suggested_message"),
+        action.get("status", "pending"),
+        json.dumps(action.get("metadata") or {}, ensure_ascii=False),
+    )
+    with _connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute(sql, params)
+            return cur.fetchone() is not None  # RETURNING id solo si insertó
+
+
+def is_idemp_executed_pg(idemp_key: str) -> bool:
+    """True si el idemp_key ya está marcado ejecutado en el ledger."""
+    if not idemp_key:
+        return False
+    sql = """
+        SELECT 1 FROM hv_pending_actions
+        WHERE idemp_key = %s
+          AND status IN ('executed', 'dry_run_executed')
+        LIMIT 1
+    """
+    with _connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute(sql, (idemp_key,))
+            return cur.fetchone() is not None
+
+
+def mark_pending_executed_pg(idemp_key: str, *, dry_run: bool = False) -> None:
+    """Marca el idemp_key como ejecutado en el ledger (idempotente)."""
+    if not idemp_key:
+        return
+    status = "dry_run_executed" if dry_run else "executed"
+    sql = """
+        UPDATE hv_pending_actions
+        SET status = %s, executed_at = NOW()
+        WHERE idemp_key = %s
+    """
+    with _connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute(sql, (status, idemp_key))

--- a/rag-bot/test_c1_idempotency.py
+++ b/rag-bot/test_c1_idempotency.py
@@ -1,0 +1,95 @@
+"""
+C1 idempotency tests — proactive pending actions are persisted/executed exactly once
+per logical signal (idemp_key), in file mode (no DB needed).
+
+Postgres ledger path (hv_pending_actions + ON CONFLICT) is exercised in nightly /
+manually against a real DB; here we cover the file-mode dedup + execute short-circuit.
+
+Run: python -m pytest rag-bot/test_c1_idempotency.py -q
+"""
+import os
+import tempfile
+import unittest
+
+# Force file mode + isolated dirs BEFORE importing action_handler paths are resolved lazily,
+# but set here so each call resolves the temp dir.
+from action_handler import (
+    persist_pending_action,
+    execute_pending_action,
+    load_pending_actions,
+    is_idemp_already_executed,
+    generate_action_for_signal,
+)
+from signal_detector import BetaSignal
+
+
+def _action(idemp_suffix: str = "h0", status: str = "pending"):
+    return {
+        "beta_id": "bX",
+        "action_id": f"act-bX-no_activity_7d-{idemp_suffix}",
+        "idemp_key": f"bX:no_activity_7d:followup:{idemp_suffix}",
+        "signal": {"signal_type": "no_activity_7d"},
+        "signal_type": "no_activity_7d",
+        "action_type": "reengage",
+        "phase": "followup",
+        "suggested_message": "Hola, retomemos.",
+        "status": status,
+    }
+
+
+class TestC1Idempotency(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        os.environ["HV_STATE_PERSISTENCE"] = "files"  # no Postgres ledger
+        os.environ["HV_PENDING_ACTIONS_DIR"] = self._tmp.name
+        os.environ["HV_TRACES_DIR"] = self._tmp.name
+        os.environ["HV_DECISION_LOG_ENABLED"] = "false"
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def test_persist_dedups_by_idemp_key(self):
+        a = _action("h1")
+        persist_pending_action(dict(a))
+        persist_pending_action(dict(a))  # duplicate logical signal
+        pending = load_pending_actions(limit=100)
+        same = [p for p in pending if p.get("idemp_key") == a["idemp_key"]]
+        self.assertEqual(len(same), 1, "same idemp_key must persist only once")
+
+    def test_execute_twice_is_idempotent(self):
+        a = _action("h2")
+        persist_pending_action(dict(a))
+        pend = [p for p in load_pending_actions(limit=100) if p["idemp_key"] == a["idemp_key"]][0]
+
+        r1 = execute_pending_action(dict(pend), dry_run=True)
+        self.assertEqual(r1.get("status"), "dry_run_executed")
+        self.assertTrue(is_idemp_already_executed(a["idemp_key"]))
+
+        # A second execution of the same logical action short-circuits, no side effects.
+        r2 = execute_pending_action(dict(pend), dry_run=True)
+        self.assertEqual(r2.get("status"), "already_executed")
+
+    def test_repersist_after_execute_does_not_requeue(self):
+        a = _action("h3")
+        persist_pending_action(dict(a))
+        pend = [p for p in load_pending_actions(limit=100) if p["idemp_key"] == a["idemp_key"]][0]
+        execute_pending_action(dict(pend), dry_run=True)
+        # run_detect_and_act re-generating the same signal must NOT re-queue it
+        persist_pending_action(_action("h3"))
+        pending_same = [p for p in load_pending_actions(limit=100) if p.get("idemp_key") == a["idemp_key"]]
+        self.assertEqual(len(pending_same), 0, "already-executed idemp_key must not be re-queued")
+
+    def test_generate_action_has_stable_idemp_key(self):
+        sig = BetaSignal("bY", "no_activity_72h", "medium", {"phase": "followup"})
+        try:
+            a1 = generate_action_for_signal(sig)
+            a2 = generate_action_for_signal(sig)
+        except Exception as e:  # pragma: no cover - state_manager unavailable in some envs
+            self.skipTest(f"generate_action_for_signal needs state_manager: {e}")
+        self.assertIn("idemp_key", a1)
+        self.assertTrue(a1["idemp_key"].startswith("bY:no_activity_72h:"))
+        self.assertEqual(a1["idemp_key"], a2["idemp_key"], "idemp_key must be stable for same signal+hour")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Implementa el enhancement trackeado en #31: idempotencia **exactly-once por signal lógico** en el lazo proactivo.

## Problema
El path proactivo deduplicaba solo best-effort: `persist_pending_action` hacía append a JSONL **sin clave estable** (el `action_id` lleva timestamp por-segundo), así que el mismo signal desde el cron + un run manual generaba acciones pending/executed **duplicadas** → riesgo de doble-mensaje a un beta.

## Solución (adaptada a la estructura de origin, no copia del orphan)
- **`idemp_key` estable** en `generate_action_for_signal`: `beta_id:signal_type:phase:hour_bucket` (sin timestamp por-segundo).
- **`persist_pending_action` idempotente**:
  - Postgres = **ledger atómico**: `hv_pending_actions` (migración **003**, `idemp_key UNIQUE` + `ON CONFLICT DO NOTHING`) → dedup cross-process incluso bajo concurrencia (cron + API).
  - Files = dedup escaneando pending+executed por `idemp_key`.
  - El JSONL sigue siendo el **store operativo** (load/execute sin cambios).
- **`execute_pending_action`** hace short-circuit con `is_idemp_already_executed` **antes de cualquier side-effect**; al ejecutar marca el ledger PG (best-effort).
- **`state_persistence`**: `pending_pg_enabled` / `persist_pending_action_pg` (devuelve si insertó) / `is_idemp_executed_pg` / `mark_pending_executed_pg`.

## Diseño clave
El **archivo es el store operativo siempre**; Postgres es un **ledger de idempotencia**. Así no se rompe el flujo file-mode actual (que es lo que corre el cron hoy) y se gana dedup atómico cuando migren a `HV_STATE_PERSISTENCE=postgres`.

## Tests
`test_c1_idempotency.py` (file mode, sin DB) — **4 passed**: persist dedup, execute-twice short-circuit, no re-queue tras ejecutar, idemp_key estable. Cableado al gate de `rag-bot-ci`. El path del ledger Postgres se ejercita contra DB real (nightly/manual, requiere aplicar migración 003).

Verificado local: gate+C1 **38 passed**, `proactive_golden` PASSED, dry cycle OK.

## Follow-up de ops
Aplicar `migrations/003_hv_pending_actions.sql` a Neon/Postgres cuando se active `HV_STATE_PERSISTENCE=postgres`.

Closes #31.

🤖 Generated with [Claude Code](https://claude.com/claude-code)