### PR TITLE
chore(deploy): auto-apply migration 003 on entrypoint

### DIFF
--- a/rag-bot/scripts/docker_entrypoint.sh
+++ b/rag-bot/scripts/docker_entrypoint.sh
@@ -17,6 +17,9 @@ if [ -n "${HV_DATABASE_URL:-}" ]; then
   echo "[entrypoint] apply migration 002 (hv_beta_states + hv_agent_traces)"
   python -c "from pgvector_retrieval import run_migration; run_migration('migrations/002_hv_beta_states.sql')" || \
     echo "[entrypoint] WARN: migration 002 failed — state/traces may be unavailable"
+  echo "[entrypoint] apply migration 003 (hv_pending_actions — idempotencia C1)"
+  python -c "from pgvector_retrieval import run_migration; run_migration('migrations/003_hv_pending_actions.sql')" || \
+    echo "[entrypoint] WARN: migration 003 failed — proactive idempotency ledger unavailable"
 fi
 
 EMBEDDED_NEW=0


### PR DESCRIPTION
Completa el ops follow-up de #37 (idempotencia C1): que la migración **003** (`hv_pending_actions`) se aplique sola en cada deploy, igual que la 002.

## Cambio
3 líneas en `rag-bot/scripts/docker_entrypoint.sh`, dentro del bloque `if [ -n "$HV_DATABASE_URL" ]` (junto a la 002):
```sh
echo "[entrypoint] apply migration 003 (hv_pending_actions — idempotencia C1)"
python -c "from pgvector_retrieval import run_migration; run_migration('migrations/003_hv_pending_actions.sql')" || \
  echo "[entrypoint] WARN: migration 003 failed — proactive idempotency ledger unavailable"
```

## Efecto
Al mergear (push a main → `rag-bot-fly-deploy.yml`), el contenedor de Fly aplica 002 **y 003** al arrancar usando su secret `HV_DATABASE_URL`. No requiere correr nada a mano ni manejar la URL local. La migración es idempotente (`CREATE TABLE IF NOT EXISTS`) y `|| WARN` no tumba el arranque si falla.

Para activar el ledger de verdad: `HV_STATE_PERSISTENCE=postgres` en los secrets de Fly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)