### PR TITLE
feat(whatsapp): canal Twilio — webhook inbound + sender real proactivo

### DIFF
--- a/.github/workflows/rag-bot-ci.yml
+++ b/.github/workflows/rag-bot-ci.yml
@@ -54,7 +54,8 @@ jobs:
             test_beta_state.py \
             test_api_rag.py \
             test_newsletter_approval.py \
-            test_c1_idempotency.py
+            test_c1_idempotency.py \
+            test_whatsapp_channel.py
 
       - name: Golden set (gates-only)
         run: python golden_runner.py --gates-only

--- a/rag-bot/action_handler.py
+++ b/rag-bot/action_handler.py
@@ -769,8 +769,38 @@ def execute_pending_action(action: Dict[str, Any], *, dry_run: bool = False, for
     if dry_run:
         print(f"[execute][dry-run] Would send to {beta_id}: {message[:80]}...")
     else:
-        # Real execution path (only reached if dry_run or force or is_healthy)
-        print(f"[execute] SENT to {beta_id}: {message[:80]}...")
+        # Real execution path (only reached if dry_run or force or is_healthy).
+        # REAL_SENDER flag (default OFF) gates actual WhatsApp delivery via Twilio.
+        # On send failure the action STAYS pending (no mark, no state bump) so the
+        # next cycle retries — e.g. free-form outside the 24h window until the
+        # Meta-approved template (TWILIO_CONTENT_SID_PROACTIVE) is configured.
+        if is_enabled("REAL_SENDER", default=False):
+            try:
+                from whatsapp_channel import (
+                    ChannelSendError, phone_for_beta, send_whatsapp, twilio_configured,
+                )
+                if not twilio_configured():
+                    raise ChannelSendError("Twilio creds missing")
+                to_phone = phone_for_beta(beta_id)
+                if not to_phone:
+                    raise ChannelSendError(f"no phone known for beta {beta_id}")
+                content_sid = os.getenv("TWILIO_CONTENT_SID_PROACTIVE") or None
+                receipt = send_whatsapp(
+                    to_phone, message,
+                    content_sid=content_sid,
+                    content_variables={"1": message} if content_sid else None,
+                )
+                action = dict(action)
+                action["delivery"] = {"channel": "whatsapp", **receipt}
+                print(f"[execute] SENT (twilio sid={receipt.get('sid')}) to {beta_id}: {message[:80]}...")
+            except Exception as e:
+                print(f"[execute][send-failed] beta={beta_id}: {e}. Action stays pending.")
+                out = dict(action)
+                out["status"] = "send_failed"
+                out["send_error"] = str(e)[:300]
+                return out
+        else:
+            print(f"[execute] SENT (simulated; REAL_SENDER off) to {beta_id}: {message[:80]}...")
 
         # Record in BetaState that a proactive outreach happened.
         # This is important so future signal detection can take it into account

--- a/rag-bot/api/main.py
+++ b/rag-bot/api/main.py
@@ -11,9 +11,9 @@ from pathlib import Path
 from typing import Literal, Optional
 
 from dotenv import load_dotenv
-from fastapi import FastAPI, Header, HTTPException, Query
+from fastapi import FastAPI, Header, HTTPException, Query, Request
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import HTMLResponse, JSONResponse
+from fastapi.responses import HTMLResponse, JSONResponse, Response
 from pydantic import BaseModel, Field
 
 # Cargar .env desde rag-bot/ aunque uvicorn arranque desde api/
@@ -33,6 +33,12 @@ from traces import get_trace_stats, read_traces  # noqa: E402
 from signal_detector import BetaSignalDetector  # noqa: E402
 from action_handler import load_pending_actions, run_detect_and_act, get_proactive_health_trend  # noqa: E402
 from feature_flags import list_active_flags, is_enabled  # noqa: E402  # Guía Capa 5
+from whatsapp_channel import (  # noqa: E402
+    beta_id_for_phone,
+    twiml_empty,
+    twiml_reply,
+    validate_twilio_signature,
+)
 
 app = FastAPI(
     title="Hombre Vigente RAG API",
@@ -583,6 +589,73 @@ def newsletter_approve(
     else:
         msg = "Solicitud de cambios recibida. Recibirás un nuevo borrador por correo."
     return HTMLResponse(_approval_page(True, msg))
+
+
+# ------------------------------------------------------------------
+# WhatsApp (Twilio) — webhook inbound: turn + last_active + concierge RAG
+# ------------------------------------------------------------------
+
+_WA_FALLBACK_REPLY = (
+    "Recibido. En un momento te respondemos con calma — "
+    "si es urgente, escribe 'humano' y te conectamos con el equipo."
+)
+
+
+def _twilio_public_url(request: Request) -> str:
+    """Twilio firma la URL pública (https tras el proxy de Fly)."""
+    url = str(request.url)
+    proto = request.headers.get("x-forwarded-proto")
+    if proto and url.startswith("http://") and proto == "https":
+        url = "https://" + url[len("http://"):]
+    return url
+
+
+@app.post("/webhook/whatsapp")
+async def whatsapp_webhook(request: Request):
+    """
+    Inbound de Twilio (form-encoded). Efectos por mensaje:
+    1. record_turn(channel='whatsapp') → bump de last_active_at (apaga señales
+       de inactividad del lazo proactivo de forma natural).
+    2. Respuesta concierge vía RAG (gates + confianza ya integrados en _run_query).
+    Responde TwiML inline (no consume Messages API ni requiere template).
+    """
+    form = {k: str(v) for k, v in (await request.form()).items()}
+
+    # Firma (fail-closed). HV_TWILIO_VALIDATE=false solo para dev/tests.
+    if os.getenv("HV_TWILIO_VALIDATE", "true").strip().lower() not in ("false", "0", "no"):
+        sig = request.headers.get("X-Twilio-Signature", "")
+        if not validate_twilio_signature(_twilio_public_url(request), form, sig):
+            raise HTTPException(status_code=403, detail="invalid twilio signature")
+
+    from_phone = form.get("From", "")
+    body = (form.get("Body") or "").strip()
+    if not from_phone:
+        return Response(content=twiml_empty(), media_type="application/xml")
+
+    beta_id = beta_id_for_phone(from_phone)
+
+    try:
+        from state_manager import state_manager as _sm
+        _sm.record_turn(beta_id, channel="whatsapp")
+    except Exception as e:
+        print(f"[wa-webhook] WARN record_turn({beta_id}): {e}")
+
+    if not body:
+        return Response(content=twiml_empty(), media_type="application/xml")
+
+    reply = _WA_FALLBACK_REPLY
+    try:
+        res = _run_query(
+            body, role="concierge", use_llm=True,
+            beta_id=beta_id, channel="whatsapp",
+        )
+        ans = (res or {}).get("answer") or ""
+        if ans.strip():
+            reply = ans.strip()
+    except Exception as e:
+        print(f"[wa-webhook] WARN rag failed for {beta_id}: {e}")
+
+    return Response(content=twiml_reply(reply), media_type="application/xml")
 
 
 @app.get("/rag/query")

--- a/rag-bot/requirements-fly.txt
+++ b/rag-bot/requirements-fly.txt
@@ -6,3 +6,4 @@ python-multipart==0.0.6
 python-dotenv>=1.0.0
 openai>=1.12.0
 psycopg[binary]>=3.1.18
+requests>=2.31  # Twilio Messages API (whatsapp_channel.py)

--- a/rag-bot/requirements-rag-ci.txt
+++ b/rag-bot/requirements-rag-ci.txt
@@ -6,3 +6,5 @@ python-dotenv>=1.0.0
 pytest>=8.0
 fastapi>=0.110
 httpx>=0.27
+requests>=2.31
+python-multipart>=0.0.6

--- a/rag-bot/test_whatsapp_channel.py
+++ b/rag-bot/test_whatsapp_channel.py
@@ -1,0 +1,202 @@
+"""
+Tests del canal WhatsApp (Twilio) — sin red ni credenciales reales.
+
+Cubre: normalización/lookup de teléfonos, validación de firma Twilio (vector
+calculado con el mismo esquema oficial), webhook inbound (TwiML + record_turn),
+y el sender real en execute_pending_action (flag REAL_SENDER, fallo → pending).
+
+Run: python -m pytest rag-bot/test_whatsapp_channel.py -q
+"""
+import base64
+import hashlib
+import hmac
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from whatsapp_channel import (
+    ChannelSendError,
+    beta_id_for_phone,
+    normalize_phone,
+    phone_for_beta,
+    send_whatsapp,
+    twiml_reply,
+    validate_twilio_signature,
+)
+
+
+class TestPhones(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        os.environ["HV_INTAKE_DIR"] = self._tmp.name
+        os.environ["HV_WA_CONTACTS"] = str(Path(self._tmp.name) / "wa_contacts.json")
+        intake = {
+            "meta": {"beta_id": "caso0"},
+            "identity": {"nombre": "Juan", "whatsapp": "+524421000000"},
+        }
+        (Path(self._tmp.name) / "caso0_intake.json").write_text(
+            json.dumps(intake), encoding="utf-8"
+        )
+
+    def tearDown(self):
+        self._tmp.cleanup()
+        os.environ.pop("HV_INTAKE_DIR", None)
+        os.environ.pop("HV_WA_CONTACTS", None)
+
+    def test_normalize(self):
+        self.assertEqual(normalize_phone("whatsapp:+52 442-100-0000"), "+524421000000")
+        self.assertEqual(normalize_phone(""), "")
+
+    def test_lookup_by_intake_and_reverse(self):
+        self.assertEqual(beta_id_for_phone("whatsapp:+524421000000"), "caso0")
+        self.assertEqual(phone_for_beta("caso0"), "+524421000000")
+
+    def test_unknown_phone_bootstraps_deterministic_id(self):
+        self.assertEqual(beta_id_for_phone("+525599887766"), "wa-525599887766")
+        self.assertEqual(phone_for_beta("wa-525599887766"), "+525599887766")
+
+    def test_registry_wins(self):
+        Path(os.environ["HV_WA_CONTACTS"]).write_text(
+            json.dumps({"+524421000000": "beta-registry"}), encoding="utf-8"
+        )
+        self.assertEqual(beta_id_for_phone("+524421000000"), "beta-registry")
+
+
+class TestSignature(unittest.TestCase):
+    def test_valid_and_invalid(self):
+        token = "secret-token"
+        url = "https://hv-rag-api.fly.dev/webhook/whatsapp"
+        params = {"From": "whatsapp:+521234567890", "Body": "hola"}
+        payload = url + "".join(k + params[k] for k in sorted(params))
+        sig = base64.b64encode(
+            hmac.new(token.encode(), payload.encode(), hashlib.sha1).digest()
+        ).decode()
+        self.assertTrue(validate_twilio_signature(url, params, sig, token))
+        self.assertFalse(validate_twilio_signature(url, params, "bad" + sig, token))
+        self.assertFalse(validate_twilio_signature(url, params, "", token))
+
+
+class TestWebhook(unittest.TestCase):
+    def setUp(self):
+        os.environ["HV_TWILIO_VALIDATE"] = "false"  # firma cubierta en TestSignature
+        self._tmp = tempfile.TemporaryDirectory()
+        os.environ["HV_BETA_STATES_DIR"] = self._tmp.name
+        os.environ["HV_INTAKE_DIR"] = self._tmp.name
+        os.environ["HV_DECISION_LOG_ENABLED"] = "false"
+        from fastapi.testclient import TestClient
+        from api.main import app
+        self.client = TestClient(app)
+
+    def tearDown(self):
+        self._tmp.cleanup()
+        for k in ("HV_TWILIO_VALIDATE", "HV_BETA_STATES_DIR", "HV_INTAKE_DIR"):
+            os.environ.pop(k, None)
+
+    def test_inbound_replies_twiml_and_records_turn(self):
+        r = self.client.post(
+            "/webhook/whatsapp",
+            data={"From": "whatsapp:+525511122233", "Body": "hola, ¿qué es HIFU?"},
+        )
+        self.assertEqual(r.status_code, 200)
+        self.assertIn("application/xml", r.headers["content-type"])
+        self.assertIn("<Response><Message>", r.text)
+        # record_turn debió bootstrapear el estado del lead wa-…
+        state_file = Path(self._tmp.name) / "wa-525511122233.json"
+        self.assertTrue(state_file.exists(), "webhook must bootstrap beta state")
+        state = json.loads(state_file.read_text())
+        self.assertEqual(state.get("last_channel"), "whatsapp")
+
+    def test_missing_signature_rejected_when_validation_on(self):
+        os.environ["HV_TWILIO_VALIDATE"] = "true"
+        os.environ["TWILIO_AUTH_TOKEN"] = "tok"
+        try:
+            r = self.client.post(
+                "/webhook/whatsapp", data={"From": "whatsapp:+5255", "Body": "x"}
+            )
+            self.assertEqual(r.status_code, 403)
+        finally:
+            os.environ["HV_TWILIO_VALIDATE"] = "false"
+            os.environ.pop("TWILIO_AUTH_TOKEN", None)
+
+
+class TestRealSender(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        os.environ.update({
+            "HV_STATE_PERSISTENCE": "files",
+            "HV_PENDING_ACTIONS_DIR": self._tmp.name,
+            "HV_TRACES_DIR": self._tmp.name,
+            "HV_BETA_STATES_DIR": self._tmp.name,
+            "HV_INTAKE_DIR": self._tmp.name,
+            "HV_DECISION_LOG_ENABLED": "false",
+        })
+
+    def tearDown(self):
+        self._tmp.cleanup()
+        for k in ("HV_FEATURE_REAL_SENDER", "TWILIO_ACCOUNT_SID",
+                  "TWILIO_AUTH_TOKEN", "TWILIO_WHATSAPP_FROM"):
+            os.environ.pop(k, None)
+
+    def _pending_action(self, suffix="s1"):
+        return {
+            "beta_id": "wa-525500000001",
+            "action_id": f"act-{suffix}",
+            "idemp_key": f"wa-525500000001:no_activity_72h:followup:{suffix}",
+            "signal": {"signal_type": "no_activity_72h"},
+            "action_type": "reengage",
+            "suggested_message": "Hola, retomemos tu protocolo.",
+            "status": "pending",
+        }
+
+    def test_flag_off_keeps_simulated_path(self):
+        from action_handler import execute_pending_action
+        r = execute_pending_action(self._pending_action("off"), dry_run=False, force=True)
+        self.assertEqual(r.get("status"), "executed")  # simulado, como antes
+
+    def test_send_failure_leaves_action_pending(self):
+        os.environ["HV_FEATURE_REAL_SENDER"] = "true"
+        # Twilio sin configurar → ChannelSendError → send_failed, NO executed
+        from action_handler import execute_pending_action, is_idemp_already_executed
+        a = self._pending_action("fail")
+        r = execute_pending_action(a, dry_run=False, force=True)
+        self.assertEqual(r.get("status"), "send_failed")
+        self.assertFalse(is_idemp_already_executed(a["idemp_key"]))
+
+    def test_send_success_marks_executed_with_receipt(self):
+        os.environ["HV_FEATURE_REAL_SENDER"] = "true"
+        os.environ["TWILIO_ACCOUNT_SID"] = "ACtest"
+        os.environ["TWILIO_AUTH_TOKEN"] = "tok"
+        os.environ["TWILIO_WHATSAPP_FROM"] = "whatsapp:+14155238886"
+
+        class _Resp:
+            status_code = 201
+            text = "{}"
+            @staticmethod
+            def json():
+                return {"sid": "SM123", "status": "queued"}
+
+        from action_handler import execute_pending_action
+        with patch("requests.post", return_value=_Resp()) as mock_post:
+            r = execute_pending_action(self._pending_action("ok"), dry_run=False, force=True)
+        self.assertEqual(r.get("status"), "executed")
+        self.assertEqual(r.get("delivery", {}).get("sid"), "SM123")
+        sent = mock_post.call_args.kwargs.get("data") or mock_post.call_args[1].get("data")
+        self.assertEqual(sent["To"], "whatsapp:+525500000001")
+
+    def test_send_whatsapp_requires_creds(self):
+        with self.assertRaises(ChannelSendError):
+            send_whatsapp("+5255", "hola")
+
+
+class TestTwiml(unittest.TestCase):
+    def test_escapes_and_truncates(self):
+        xml = twiml_reply("<b>hola & adiós</b>" + "x" * 2000)
+        self.assertIn("&lt;b&gt;hola &amp; adiós&lt;/b&gt;", xml)
+        self.assertLess(len(xml), 1700)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rag-bot/whatsapp_channel.py
+++ b/rag-bot/whatsapp_channel.py
@@ -1,0 +1,199 @@
+"""
+whatsapp_channel.py — Canal WhatsApp vía Twilio (Día 1 del plan WhatsApp-nativo).
+
+Piezas:
+- normalize_phone / lookup_beta_by_phone / phone_for_beta: mapeo E.164 ↔ beta_id.
+  Fuentes: registry opcional data/wa_contacts.json ({"+52...": "beta-id"}) y los
+  intakes en HV_INTAKE_DIR (identity.whatsapp). Número desconocido → beta_id
+  determinístico "wa-<dígitos>" (bootstrap de lead; state_manager crea el estado).
+- validate_twilio_signature: X-Twilio-Signature (HMAC-SHA1 base64 del URL + params
+  ordenados, firmado con el auth token) — stdlib, sin SDK de Twilio.
+- send_whatsapp: POST a la API de mensajes de Twilio (requests). Texto libre
+  (ventana 24h) o template aprobado vía content_sid/content_variables.
+- twiml_reply: respuesta inline al webhook (no consume API ni requiere creds).
+
+Env:
+  TWILIO_ACCOUNT_SID / TWILIO_AUTH_TOKEN / TWILIO_WHATSAPP_FROM ("whatsapp:+1...")
+  HV_TWILIO_VALIDATE=false  → salta validación de firma (solo dev/tests)
+  HV_INTAKE_DIR (default data/intake) / HV_WA_CONTACTS (default data/wa_contacts.json)
+"""
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import os
+import re
+from pathlib import Path
+from typing import Any, Dict, Optional
+from xml.sax.saxutils import escape
+
+TWILIO_API = "https://api.twilio.com/2010-04-01"
+# WhatsApp corta cuerpos >1600 chars; dejamos margen.
+MAX_BODY_CHARS = 1500
+
+
+class ChannelSendError(Exception):
+    """El envío vía Twilio falló (HTTP != 2xx o sin credenciales)."""
+
+
+def twilio_configured() -> bool:
+    return bool(
+        os.getenv("TWILIO_ACCOUNT_SID")
+        and os.getenv("TWILIO_AUTH_TOKEN")
+        and os.getenv("TWILIO_WHATSAPP_FROM")
+    )
+
+
+# ------------------------------------------------------------------
+# Teléfonos ↔ betas
+# ------------------------------------------------------------------
+
+def normalize_phone(raw: str) -> str:
+    """'whatsapp:+52 442-100-0000' → '+524421000000'. Sin dígitos → ''."""
+    digits = re.sub(r"\D", "", raw or "")
+    return f"+{digits}" if digits else ""
+
+
+def _contacts_path() -> Path:
+    return Path(os.getenv("HV_WA_CONTACTS", "data/wa_contacts.json"))
+
+
+def _intake_dir() -> Path:
+    return Path(os.getenv("HV_INTAKE_DIR", "data/intake"))
+
+
+def _iter_intakes():
+    base = _intake_dir()
+    if not base.exists():
+        return
+    for p in sorted(base.glob("*.json")):
+        try:
+            yield p, json.loads(p.read_text(encoding="utf-8"))
+        except Exception:
+            continue
+
+
+def lookup_beta_by_phone(phone: str) -> Optional[str]:
+    """Registry primero, luego intakes (identity.whatsapp). None si no hay match."""
+    phone = normalize_phone(phone)
+    if not phone:
+        return None
+    try:
+        reg = json.loads(_contacts_path().read_text(encoding="utf-8"))
+        for k, v in reg.items():
+            if normalize_phone(k) == phone and v:
+                return str(v)
+    except Exception:
+        pass
+    for path, intake in _iter_intakes() or []:
+        ident = (intake.get("identity") or {})
+        if normalize_phone(ident.get("whatsapp", "")) == phone:
+            beta = (intake.get("meta") or {}).get("beta_id")
+            return str(beta) if beta else path.stem.replace("_intake", "")
+    return None
+
+
+def beta_id_for_phone(phone: str) -> str:
+    """beta_id conocido o bootstrap determinístico 'wa-<dígitos>' para leads."""
+    known = lookup_beta_by_phone(phone)
+    if known:
+        return known
+    return f"wa-{normalize_phone(phone).lstrip('+')}"
+
+
+def phone_for_beta(beta_id: str) -> Optional[str]:
+    """Inverso (para el sender proactivo): registry, luego intakes."""
+    try:
+        reg = json.loads(_contacts_path().read_text(encoding="utf-8"))
+        for k, v in reg.items():
+            if str(v) == beta_id:
+                return normalize_phone(k)
+    except Exception:
+        pass
+    for path, intake in _iter_intakes() or []:
+        beta = (intake.get("meta") or {}).get("beta_id") or path.stem.replace("_intake", "")
+        if str(beta) == beta_id:
+            p = normalize_phone((intake.get("identity") or {}).get("whatsapp", ""))
+            if p:
+                return p
+    # bootstrap ids llevan el número embebido
+    if beta_id.startswith("wa-") and beta_id[3:].isdigit():
+        return f"+{beta_id[3:]}"
+    return None
+
+
+# ------------------------------------------------------------------
+# Firma de Twilio (X-Twilio-Signature)
+# ------------------------------------------------------------------
+
+def validate_twilio_signature(url: str, params: Dict[str, str], signature: str,
+                              auth_token: Optional[str] = None) -> bool:
+    """Esquema oficial: base64(HMAC-SHA1(url + Σ key+value ordenados, auth_token))."""
+    token = auth_token or os.getenv("TWILIO_AUTH_TOKEN", "")
+    if not token or not signature:
+        return False
+    payload = url + "".join(k + params[k] for k in sorted(params))
+    digest = hmac.new(token.encode(), payload.encode("utf-8"), hashlib.sha1).digest()
+    expected = base64.b64encode(digest).decode()
+    return hmac.compare_digest(expected, signature)
+
+
+# ------------------------------------------------------------------
+# Envío (proactivo / fuera del ciclo request-reply)
+# ------------------------------------------------------------------
+
+def send_whatsapp(to_phone: str, body: str = "", *,
+                  content_sid: Optional[str] = None,
+                  content_variables: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    """
+    Envía por la Messages API de Twilio. Texto libre solo entra en ventana de 24h;
+    para mensajes iniciados por el bot usa content_sid (template aprobado por Meta).
+    Lanza ChannelSendError si no hay creds o Twilio responde error — el caller
+    decide si la acción queda pending (sí: ver execute_pending_action).
+    """
+    import requests  # lazy: file-mode/tests no lo requieren
+
+    sid = os.getenv("TWILIO_ACCOUNT_SID", "")
+    token = os.getenv("TWILIO_AUTH_TOKEN", "")
+    from_ = os.getenv("TWILIO_WHATSAPP_FROM", "")
+    if not (sid and token and from_):
+        raise ChannelSendError("Twilio no configurado (TWILIO_ACCOUNT_SID/AUTH_TOKEN/WHATSAPP_FROM)")
+
+    to = normalize_phone(to_phone)
+    if not to:
+        raise ChannelSendError(f"Teléfono destino inválido: {to_phone!r}")
+
+    data: Dict[str, str] = {
+        "From": from_ if from_.startswith("whatsapp:") else f"whatsapp:{from_}",
+        "To": f"whatsapp:{to}",
+    }
+    if content_sid:
+        data["ContentSid"] = content_sid
+        if content_variables:
+            data["ContentVariables"] = json.dumps(content_variables, ensure_ascii=False)
+    else:
+        data["Body"] = (body or "")[:MAX_BODY_CHARS]
+
+    resp = requests.post(
+        f"{TWILIO_API}/Accounts/{sid}/Messages.json",
+        data=data, auth=(sid, token), timeout=30,
+    )
+    if resp.status_code // 100 != 2:
+        raise ChannelSendError(f"Twilio {resp.status_code}: {resp.text[:300]}")
+    out = resp.json()
+    return {"sid": out.get("sid"), "status": out.get("status"), "to": to}
+
+
+# ------------------------------------------------------------------
+# Respuesta inline al webhook (TwiML)
+# ------------------------------------------------------------------
+
+def twiml_reply(text: str) -> str:
+    body = escape((text or "").strip()[:MAX_BODY_CHARS])
+    return f'<?xml version="1.0" encoding="UTF-8"?><Response><Message>{body}</Message></Response>'
+
+
+def twiml_empty() -> str:
+    return '<?xml version="1.0" encoding="UTF-8"?><Response></Response>'


### PR DESCRIPTION
**Día 1 del plan WhatsApp-nativo**: el canal real vía Twilio. Mata el send simulado del lazo proactivo y abre el inbound concierge. (Incremento 2 — intake conversacional que mata a Tally — va aparte.)

## Qué incluye
- **`whatsapp_channel.py`**: mapeo teléfono↔beta (registry `data/wa_contacts.json` + intakes `identity.whatsapp`; número desconocido → lead determinístico `wa-<dígitos>`), validación de firma `X-Twilio-Signature` (HMAC-SHA1 stdlib, sin SDK), `send_whatsapp` (texto libre o template Meta vía `TWILIO_CONTENT_SID_PROACTIVE`), helpers TwiML.
- **`POST /webhook/whatsapp`**: firma fail-closed → `record_turn(channel=whatsapp)` (bump de `last_active_at` = apaga señales de inactividad solas) → respuesta concierge vía `_run_query` existente (RAG + gates + confianza) → TwiML inline (las respuestas no consumen Messages API).
- **Sender real en `execute_pending_action`**: gated por flag **`REAL_SENDER` default OFF** → mergear esto NO envía nada. Si el envío falla (p.ej. fuera de ventana 24h sin template), la acción **queda pending** y se reintenta el siguiente ciclo. Éxito adjunta receipt (`twilio sid`). El C1 (#37) protege contra doble-envío.

## Verificación
12 tests nuevos (teléfonos / firma / webhook con TestClient / sender con mock) cableados al gate de CI. Gate completo **50 passed**; golden proactivo y dry cycle intactos.

## Para activarlo (ops — tu parte)
1. Twilio: comprar número + activar WhatsApp sender (vincular Meta Business).
2. Secrets en Fly: `TWILIO_ACCOUNT_SID`, `TWILIO_AUTH_TOKEN`, `TWILIO_WHATSAPP_FROM` (`whatsapp:+52...`).
3. Configurar webhook del número en Twilio → `https://hv-rag-api.fly.dev/webhook/whatsapp` (POST). Inbound queda vivo.
4. Someter templates proactivos a Meta (los textos ya están en `action_handler`); al aprobarse → `TWILIO_CONTENT_SID_PROACTIVE=HX...`.
5. Encender envío real: `HV_FEATURE_REAL_SENDER=true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)