### PR TITLE
feat(whatsapp): ingesta de estudios (labs) por el hilo

### DIFF
--- a/.github/workflows/rag-bot-ci.yml
+++ b/.github/workflows/rag-bot-ci.yml
@@ -56,7 +56,8 @@ jobs:
             test_newsletter_approval.py \
             test_c1_idempotency.py \
             test_whatsapp_channel.py \
-            test_onboarding_flow.py
+            test_onboarding_flow.py \
+            test_labs_ingest.py
 
       - name: Golden set (gates-only)
         run: python golden_runner.py --gates-only

--- a/rag-bot/api/main.py
+++ b/rag-bot/api/main.py
@@ -610,6 +610,42 @@ def _twilio_public_url(request: Request) -> str:
     return url
 
 
+def _handle_inbound_media(beta_id: str, form: dict, num_media: int) -> Optional[str]:
+    """
+    Descarga el primer media soportado (PDF/imagen = estudio) e ingiere labs.
+    Devuelve el texto de respuesta, o None si el media no es un estudio (deja que
+    siga el flujo de texto). PII: el archivo se guarda en dir efímero por beta.
+    """
+    import tempfile
+    from whatsapp_channel import (
+        download_twilio_media, is_supported_labs_media, ChannelSendError,
+    )
+    from labs_ingest import ingest_labs_pdf
+
+    for i in range(num_media):
+        url = form.get(f"MediaUrl{i}", "")
+        ctype = form.get(f"MediaContentType{i}", "")
+        if not url or not is_supported_labs_media(ctype):
+            continue
+        try:
+            dest_dir = os.path.join(
+                os.getenv("HV_LABS_INBOX_DIR", tempfile.gettempdir()), beta_id
+            )
+            path = download_twilio_media(url, dest_dir, content_type=ctype,
+                                         filename_stem=f"lab_{i}")
+            result = ingest_labs_pdf(beta_id, path)
+            return result.get("summary_text") or "Recibí tu estudio, gracias."
+        except ChannelSendError as e:
+            print(f"[wa-webhook] WARN media download {beta_id}: {e}")
+            return ("Tu estudio llegó pero no pude descargarlo ahora; "
+                    "el equipo lo revisará. 🙌")
+        except Exception as e:
+            print(f"[wa-webhook] WARN media ingest {beta_id}: {e}")
+            return ("Recibí tu archivo pero no pude leerlo automáticamente; "
+                    "el equipo lo revisa a mano.")
+    return None  # ningún media soportado → seguir con el texto
+
+
 @app.post("/webhook/whatsapp")
 async def whatsapp_webhook(request: Request):
     """
@@ -639,6 +675,18 @@ async def whatsapp_webhook(request: Request):
         _sm.record_turn(beta_id, channel="whatsapp")
     except Exception as e:
         print(f"[wa-webhook] WARN record_turn({beta_id}): {e}")
+
+    # Estudios (labs) por el hilo: si el beta adjunta un PDF/imagen, lo ingerimos
+    # (parse → biomarcadores → slot labs_parseados). Gated por HV_FEATURE_WA_LABS.
+    num_media = 0
+    try:
+        num_media = int(form.get("NumMedia", "0") or "0")
+    except ValueError:
+        num_media = 0
+    if num_media > 0 and is_enabled("WA_LABS", default=True):
+        media_reply = _handle_inbound_media(beta_id, form, num_media)
+        if media_reply is not None:
+            return Response(content=twiml_reply(media_reply), media_type="application/xml")
 
     if not body:
         return Response(content=twiml_empty(), media_type="application/xml")

--- a/rag-bot/labs_ingest.py
+++ b/rag-bot/labs_ingest.py
@@ -1,0 +1,98 @@
+"""
+labs_ingest.py — Ingesta de estudios (labs) al estado del beta.
+
+Pieza 2 del intake WhatsApp-nativo: cuando el beta manda un PDF/imagen de labs por
+el hilo, esto los parsea (process_pdf de labs_intake_manual: texto PyMuPDF → visión
+OpenAI fallback → biomarcadores estructurados), guarda el resultado en el estado y
+marca el slot `labs_parseados`. Reusable fuera de WhatsApp (CLI, futura app).
+
+El resultado estructurado (PII de salud) se guarda en state["labs_result"]; el slot
+booleano `labs_parseados` avanza la máquina de fases (screening → protocolo).
+"""
+from __future__ import annotations
+
+import os
+from datetime import datetime, timezone
+from typing import Any, Dict
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def ingest_labs_pdf(beta_id: str, pdf_path: str, *, dry_run: bool = False) -> Dict[str, Any]:
+    """
+    Parsea el PDF/imagen y, si hay biomarcadores, marca labs_parseados + guarda el
+    resultado en el estado. Devuelve un resumen liviano (no expone PII en el reply):
+    {"ok", "n_markers", "flags", "method", "summary_text"}.
+    Nunca lanza hacia el caller (el webhook degrada con un mensaje amable).
+    """
+    try:
+        from scripts.labs_intake_manual import process_pdf, validate_labs_payload
+    except Exception as e:
+        return {"ok": False, "error": f"labs parser no disponible: {e}",
+                "summary_text": "No pude procesar el estudio ahora. El equipo lo revisará."}
+
+    struct_model = os.getenv("HV_LABS_STRUCT_MODEL", "gpt-4o-mini")
+    vision_model = os.getenv("HV_LABS_VISION_MODEL", "gpt-4o-mini")
+    min_text_chars = int(os.getenv("HV_LABS_MIN_TEXT_CHARS", "400"))
+
+    from pathlib import Path
+    try:
+        structured = process_pdf(
+            Path(pdf_path),
+            struct_model=struct_model,
+            vision_model=vision_model,
+            min_text_chars=min_text_chars,
+            force_vision=False,
+            dry_run=dry_run,
+        )
+    except Exception as e:
+        return {"ok": False, "error": f"parse falló: {e}",
+                "summary_text": "Tu estudio llegó pero no pude leerlo automáticamente; "
+                                "el equipo lo revisará a mano. 🙌"}
+
+    if dry_run:
+        return {"ok": True, "dry_run": True, "method": structured.get("extraction_method"),
+                "summary_text": "(dry-run) estudio recibido."}
+
+    markers = structured.get("biomarcadores") or structured.get("markers") or []
+    n = len(markers) if isinstance(markers, list) else 0
+    warnings = []
+    try:
+        warnings = validate_labs_payload(structured)
+    except Exception:
+        pass
+
+    if n == 0:
+        return {"ok": False, "n_markers": 0, "method": structured.get("extraction_method"),
+                "summary_text": "Recibí el archivo pero no detecté biomarcadores claros. "
+                                "¿Puedes reenviarlo más nítido o en PDF? Si no, el equipo lo revisa."}
+
+    # Persistir: resultado estructurado en estado + slot labs_parseados.
+    try:
+        from state_persistence import load_state, save_state, get_current_version
+        state = load_state(beta_id) or {"beta_id": beta_id}
+        state["labs_result"] = {**structured, "_ingested_at": _utc_now(),
+                                "_source_path": os.path.basename(pdf_path)}
+        try:
+            save_state(beta_id, state, expected_version=get_current_version(beta_id) or 0)
+        except Exception:
+            save_state(beta_id, state)
+    except Exception as e:
+        print(f"[labs_ingest] WARN persist labs_result({beta_id}): {e}")
+
+    try:
+        from state_manager import state_manager as sm
+        sm.fill_slot(beta_id, "labs_parseados", True)
+    except Exception as e:
+        print(f"[labs_ingest] WARN fill_slot({beta_id}): {e}")
+
+    flagged = [m for m in markers if isinstance(m, dict) and m.get("flag") not in (None, "", "normal", "ok")]
+    summary = (f"¡Recibí tu estudio! Detecté {n} biomarcadores"
+               + (f", {len(flagged)} fuera de rango para revisar con tu médico." if flagged
+                  else " dentro de lo esperado.")
+               + " Los uso para personalizar tu protocolo (esto no es diagnóstico).")
+    return {"ok": True, "n_markers": n, "flags": len(flagged),
+            "method": structured.get("extraction_method"),
+            "warnings": warnings, "summary_text": summary}

--- a/rag-bot/requirements-fly.txt
+++ b/rag-bot/requirements-fly.txt
@@ -7,3 +7,4 @@ python-dotenv>=1.0.0
 openai>=1.12.0
 psycopg[binary]>=3.1.18
 requests>=2.31  # Twilio Messages API (whatsapp_channel.py)
+pymupdf>=1.24  # labs PDF parsing (labs_ingest / process_pdf)

--- a/rag-bot/test_labs_ingest.py
+++ b/rag-bot/test_labs_ingest.py
@@ -1,0 +1,160 @@
+"""
+Tests de ingesta de labs por WhatsApp (file mode, sin red ni PDFs reales).
+
+process_pdf y la descarga de Twilio se mockean — aquí se valida el cableado:
+descarga → ingest → estado (slot labs_parseados + labs_result) → resumen, y los
+caminos de fallo (sin biomarcadores, sin creds).
+
+Run: python -m pytest rag-bot/test_labs_ingest.py -q
+"""
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from whatsapp_channel import (
+    ChannelSendError, download_twilio_media, is_supported_labs_media,
+)
+
+
+_FAKE_LABS = {
+    "biomarcadores": [
+        {"nombre": "hs-CRP", "valor": 0.8, "unidad": "mg/L", "flag": "normal"},
+        {"nombre": "Glucosa", "valor": 110, "unidad": "mg/dL", "flag": "alto"},
+        {"nombre": "HbA1c", "valor": 5.9, "unidad": "%", "flag": "alto"},
+    ],
+    "extraction_method": "text",
+}
+
+
+class TestSupportedMedia(unittest.TestCase):
+    def test_supported_types(self):
+        self.assertTrue(is_supported_labs_media("application/pdf"))
+        self.assertTrue(is_supported_labs_media("image/jpeg; charset=binary"))
+        self.assertFalse(is_supported_labs_media("audio/ogg"))
+        self.assertFalse(is_supported_labs_media(""))
+
+
+class TestDownload(unittest.TestCase):
+    def test_requires_creds(self):
+        for k in ("TWILIO_ACCOUNT_SID", "TWILIO_AUTH_TOKEN"):
+            os.environ.pop(k, None)
+        with self.assertRaises(ChannelSendError):
+            download_twilio_media("https://api.twilio.com/x", "/tmp/x")
+
+    def test_saves_with_extension_from_content_type(self):
+        os.environ["TWILIO_ACCOUNT_SID"] = "ACtest"
+        os.environ["TWILIO_AUTH_TOKEN"] = "tok"
+
+        class _R:
+            status_code = 200
+            content = b"%PDF-1.4 fake"
+            headers = {"Content-Type": "application/pdf"}
+            text = ""
+
+        with tempfile.TemporaryDirectory() as td:
+            with patch("requests.get", return_value=_R()):
+                path = download_twilio_media("https://api.twilio.com/Media/ME1", td,
+                                             content_type="application/pdf", filename_stem="lab_0")
+            self.assertTrue(path.endswith("lab_0.pdf"))
+            self.assertEqual(open(path, "rb").read(), b"%PDF-1.4 fake")
+        for k in ("TWILIO_ACCOUNT_SID", "TWILIO_AUTH_TOKEN"):
+            os.environ.pop(k, None)
+
+
+class TestIngest(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        os.environ["HV_STATE_PERSISTENCE"] = "files"
+        os.environ["HV_BETA_STATES_DIR"] = self._tmp.name
+        os.environ["HV_TRACES_DIR"] = self._tmp.name
+        os.environ["HV_DECISION_LOG_ENABLED"] = "false"
+        self.beta = "wa-525500000055"
+
+    def tearDown(self):
+        self._tmp.cleanup()
+        for k in ("HV_BETA_STATES_DIR", "HV_TRACES_DIR"):
+            os.environ.pop(k, None)
+
+    def test_ingest_fills_slot_and_stores_result(self):
+        import labs_ingest
+        from state_persistence import load_state
+        with patch("scripts.labs_intake_manual.process_pdf", return_value=dict(_FAKE_LABS)), \
+             patch("scripts.labs_intake_manual.validate_labs_payload", return_value=[]):
+            r = labs_ingest.ingest_labs_pdf(self.beta, "/tmp/lab_0.pdf")
+        self.assertTrue(r["ok"])
+        self.assertEqual(r["n_markers"], 3)
+        self.assertEqual(r["flags"], 2)  # glucosa + HbA1c fuera de rango
+        self.assertIn("biomarcadores", r["summary_text"].lower())
+
+        state = load_state(self.beta)
+        self.assertTrue((state.get("slots") or {}).get("labs_parseados"))
+        self.assertIn("labs_result", state)
+        self.assertEqual(len(state["labs_result"]["biomarcadores"]), 3)
+
+    def test_no_markers_does_not_fill_slot(self):
+        import labs_ingest
+        from state_persistence import load_state
+        with patch("scripts.labs_intake_manual.process_pdf",
+                   return_value={"biomarcadores": [], "extraction_method": "vision"}):
+            r = labs_ingest.ingest_labs_pdf(self.beta, "/tmp/empty.pdf")
+        self.assertFalse(r["ok"])
+        state = load_state(self.beta) or {}
+        self.assertFalse((state.get("slots") or {}).get("labs_parseados"))
+
+    def test_parser_exception_is_friendly(self):
+        import labs_ingest
+        with patch("scripts.labs_intake_manual.process_pdf", side_effect=RuntimeError("boom")):
+            r = labs_ingest.ingest_labs_pdf(self.beta, "/tmp/x.pdf")
+        self.assertFalse(r["ok"])
+        self.assertIn("equipo", r["summary_text"].lower())
+
+
+class TestWebhookMedia(unittest.TestCase):
+    def setUp(self):
+        os.environ["HV_TWILIO_VALIDATE"] = "false"
+        self._tmp = tempfile.TemporaryDirectory()
+        os.environ["HV_BETA_STATES_DIR"] = self._tmp.name
+        os.environ["HV_INTAKE_DIR"] = self._tmp.name
+        os.environ["HV_LABS_INBOX_DIR"] = self._tmp.name
+        os.environ["HV_DECISION_LOG_ENABLED"] = "false"
+        # No queremos que el onboarding intercepte el media en este test
+        os.environ["HV_FEATURE_WA_ONBOARDING"] = "false"
+        from fastapi.testclient import TestClient
+        from api.main import app
+        self.client = TestClient(app)
+
+    def tearDown(self):
+        self._tmp.cleanup()
+        for k in ("HV_TWILIO_VALIDATE", "HV_BETA_STATES_DIR", "HV_INTAKE_DIR",
+                  "HV_LABS_INBOX_DIR", "HV_FEATURE_WA_ONBOARDING"):
+            os.environ.pop(k, None)
+
+    def test_inbound_pdf_ingests_and_replies(self):
+        with patch("whatsapp_channel.download_twilio_media", return_value="/tmp/lab_0.pdf"), \
+             patch("labs_ingest.ingest_labs_pdf",
+                   return_value={"ok": True, "n_markers": 3, "flags": 1,
+                                 "summary_text": "¡Recibí tu estudio! Detecté 3 biomarcadores."}):
+            r = self.client.post("/webhook/whatsapp", data={
+                "From": "whatsapp:+525500000055", "Body": "",
+                "NumMedia": "1",
+                "MediaUrl0": "https://api.twilio.com/Media/ME1",
+                "MediaContentType0": "application/pdf",
+            })
+        self.assertEqual(r.status_code, 200)
+        self.assertIn("estudio", r.text.lower())
+
+    def test_unsupported_media_falls_through(self):
+        # audio → no es estudio → _handle_inbound_media devuelve None → sigue flujo de texto (vacío→empty)
+        r = self.client.post("/webhook/whatsapp", data={
+            "From": "whatsapp:+525500000056", "Body": "",
+            "NumMedia": "1",
+            "MediaUrl0": "https://api.twilio.com/Media/ME2",
+            "MediaContentType0": "audio/ogg",
+        })
+        self.assertEqual(r.status_code, 200)
+        self.assertIn("<Response>", r.text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rag-bot/whatsapp_channel.py
+++ b/rag-bot/whatsapp_channel.py
@@ -187,6 +187,51 @@ def send_whatsapp(to_phone: str, body: str = "", *,
 
 
 # ------------------------------------------------------------------
+# Descarga de media inbound (labs/estudios que el beta manda por el hilo)
+# ------------------------------------------------------------------
+
+# Solo aceptamos documentos/imágenes (estudios). Audio/video/otros se ignoran.
+_LABS_CONTENT_EXT = {
+    "application/pdf": ".pdf",
+    "image/jpeg": ".jpg",
+    "image/jpg": ".jpg",
+    "image/png": ".png",
+    "image/heic": ".heic",
+    "image/webp": ".webp",
+}
+
+
+def is_supported_labs_media(content_type: str) -> bool:
+    return (content_type or "").split(";")[0].strip().lower() in _LABS_CONTENT_EXT
+
+
+def download_twilio_media(url: str, dest_dir: str, *, content_type: str = "",
+                          filename_stem: str = "lab") -> str:
+    """
+    Descarga un media de Twilio (la MediaUrl requiere basic auth con las creds de
+    la cuenta) a dest_dir. Devuelve la ruta local. Lanza ChannelSendError si no hay
+    creds o la descarga falla. El archivo es PII (estudio) → vive en dir privado/efímero.
+    """
+    import requests  # lazy
+
+    sid = os.getenv("TWILIO_ACCOUNT_SID", "")
+    token = os.getenv("TWILIO_AUTH_TOKEN", "")
+    if not (sid and token):
+        raise ChannelSendError("Twilio no configurado (TWILIO_ACCOUNT_SID/AUTH_TOKEN)")
+
+    resp = requests.get(url, auth=(sid, token), timeout=60)
+    if resp.status_code // 100 != 2:
+        raise ChannelSendError(f"Twilio media {resp.status_code}: {resp.text[:200]}")
+
+    ct = content_type or resp.headers.get("Content-Type", "")
+    ext = _LABS_CONTENT_EXT.get(ct.split(";")[0].strip().lower(), ".bin")
+    Path(dest_dir).mkdir(parents=True, exist_ok=True)
+    dest = Path(dest_dir) / f"{filename_stem}{ext}"
+    dest.write_bytes(resp.content)
+    return str(dest)
+
+
+# ------------------------------------------------------------------
 # Respuesta inline al webhook (TwiML)
 # ------------------------------------------------------------------
 


### PR DESCRIPTION
**Pieza 2** del intake WhatsApp-nativo: el beta manda sus **estudios (labs) en el mismo hilo** y se integran a su perfil. Cierra la otra mitad de "que se integren los estudios y el onboarding por WhatsApp".

## Qué hace
- **`whatsapp_channel.download_twilio_media`** — descarga el media (basic auth Twilio), valida tipo (PDF/imagen = estudio; audio/video se ignoran), guarda en dir efímero por beta (es PII).
- **`labs_ingest.ingest_labs_pdf`** — reusa el `process_pdf` existente (texto PyMuPDF → visión OpenAI fallback → biomarcadores), guarda `labs_result` en el estado y marca el slot **`labs_parseados`** (avanza la fase screening → protocolo). Degrada amable (sin biomarcadores / parse falla / sin parser) — nunca lanza al webhook.
- **`api/main.py`** — el webhook detecta `NumMedia>0`, descarga el primer estudio soportado, ingiere y responde resumen ("Detecté N biomarcadores, K fuera de rango para revisar con tu médico — esto no es diagnóstico"). Gated por `HV_FEATURE_WA_LABS` (default ON). Media no soportado → cae al flujo de texto.

## Verificación
8 tests nuevos (tipos soportados, descarga con mock, ingest+slot, sin biomarcadores no marca slot, excepción amable, webhook con PDF mockeado, media no soportado cae a texto). `process_pdf` y descarga **mockeados** → CI no parsea PDFs reales ni necesita pymupdf/openai. Gate completo **64 passed**, golden intacto.

## Ops
- `pymupdf` agregado a `requirements-fly.txt` (prod parsea PDFs reales; ya tenía openai).
- Reusa creds de Twilio (`TWILIO_ACCOUNT_SID/AUTH_TOKEN`) — las mismas del canal.

## Siguiente
**Pieza 3**: `compute_indice_vigente` — la spec en código (labs → biomarcadores → bandas → Índice, nivel interno/ilustrativo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)