### PR TITLE
feat(indice): puente labs→Índice (nivel B) + fix bug key biomarkers

### DIFF
--- a/.github/workflows/rag-bot-ci.yml
+++ b/.github/workflows/rag-bot-ci.yml
@@ -57,6 +57,7 @@ jobs:
             test_c1_idempotency.py \
             test_whatsapp_channel.py \
             test_indice_vigente.py \
+            test_bridge_labs_indice.py \
             test_onboarding_flow.py \
             test_labs_ingest.py
 

--- a/rag-bot/indice_vigente.py
+++ b/rag-bot/indice_vigente.py
@@ -262,6 +262,75 @@ def compute_indice_longevidad(
                   derivaciones=derivaciones, completitud=completitud)
 
 
+# ------------------------------------------------------------------
+# Puente labs → inputs del Índice (mapea nombres MX + normaliza unidades)
+# ------------------------------------------------------------------
+
+# clave del Índice → patrones (regex) sobre el nombre crudo del biomarcador del lab MX.
+_LAB_SYNONYMS: Dict[str, List[str]] = {
+    "glucosa_ayuno": [r"glucosa"],  # se excluye postprandial/curva abajo
+    "hba1c": [r"hemoglobina\s+glucosilada", r"glucohemoglobina", r"hba1c", r"\ba1c\b"],
+    "apob": [r"apolipoprote[ií]na\s*b", r"\bapo\s*b\b", r"\bapob\b"],
+    "trigliceridos": [r"triglic[eé]ridos"],
+    "hs_crp": [r"prote[ií]na\s*c\s*reactiva", r"hs[\s-]?crp", r"\bpcr\s*(ultra|us|hs)", r"\bpcr\b"],
+    "homocisteina": [r"homociste[ií]na"],
+}
+# nombres que invalidan un match de glucosa (no es ayuno).
+_GLUCOSA_EXCLUDE = re.compile(r"post|2\s*h|curva|carga|tolerancia", re.IGNORECASE)
+
+
+def _parse_lab_value(value: Any) -> Optional[float]:
+    """'95 mg/dL' / '5,4' / '<0.30' → float. None si no hay número."""
+    if isinstance(value, (int, float)):
+        return float(value)
+    if not isinstance(value, str):
+        return None
+    s = value.strip().replace(",", ".")
+    m = re.search(r"[-+]?\d*\.?\d+", s)
+    return float(m.group()) if m else None
+
+
+def labs_result_to_longevidad_inputs(labs_result: Dict[str, Any]) -> Dict[str, float]:
+    """
+    Convierte el `structured` del parser (biomarkers crudos del lab MX) en los inputs
+    nombrados que espera compute_indice_longevidad. Mapea por sinónimos y normaliza
+    unidades donde es ambiguo (apoB g/L↔mg/dL). Marcadores no reconocidos se ignoran.
+    """
+    markers = (labs_result.get("biomarkers") or labs_result.get("biomarcadores")
+               or labs_result.get("markers") or [])
+    out: Dict[str, float] = {}
+    for m in markers:
+        if not isinstance(m, dict):
+            continue
+        name = (m.get("name") or "").lower()
+        val = _parse_lab_value(m.get("value"))
+        unit = (m.get("unit") or "").lower()
+        if not name or val is None:
+            continue
+        for key, patterns in _LAB_SYNONYMS.items():
+            if key in out:
+                continue  # primer match gana
+            if key == "glucosa_ayuno" and _GLUCOSA_EXCLUDE.search(name):
+                continue
+            if any(re.search(p, name) for p in patterns):
+                # apoB: g/L (0.X) → mg/dL (×100). Heurística por unidad o magnitud.
+                if key == "apob" and ("g/l" in unit or (val < 10 and "mg" not in unit)):
+                    val = val * 100.0
+                out[key] = val
+                break
+    return out
+
+
+def compute_from_labs_result(labs_result: Dict[str, Any], *,
+                             wearable: Optional[Dict[str, float]] = None,
+                             cuestionario: Optional[Dict[str, float]] = None) -> Dict[str, Any]:
+    """Atajo del puente 2→3: structured del parser → Vigente Longevidad framed."""
+    return compute_indice_longevidad(
+        labs=labs_result_to_longevidad_inputs(labs_result),
+        wearable=wearable, cuestionario=cuestionario,
+    )
+
+
 def headline_text(resultado: Dict[str, Any]) -> str:
     """
     Texto seguro para UI/WhatsApp. El claim-guard valida la parte VARIABLE (donde

--- a/rag-bot/labs_ingest.py
+++ b/rag-bot/labs_ingest.py
@@ -56,7 +56,10 @@ def ingest_labs_pdf(beta_id: str, pdf_path: str, *, dry_run: bool = False) -> Di
         return {"ok": True, "dry_run": True, "method": structured.get("extraction_method"),
                 "summary_text": "(dry-run) estudio recibido."}
 
-    markers = structured.get("biomarcadores") or structured.get("markers") or []
+    # El parser (LABS_JSON_SCHEMA) emite "biomarkers" (inglés). Aceptamos alias por
+    # robustez, pero "biomarkers" es la key real de producción.
+    markers = (structured.get("biomarkers") or structured.get("biomarcadores")
+               or structured.get("markers") or [])
     n = len(markers) if isinstance(markers, list) else 0
     warnings = []
     try:
@@ -69,12 +72,35 @@ def ingest_labs_pdf(beta_id: str, pdf_path: str, *, dry_run: bool = False) -> Di
                 "summary_text": "Recibí el archivo pero no detecté biomarcadores claros. "
                                 "¿Puedes reenviarlo más nítido o en PDF? Si no, el equipo lo revisa."}
 
-    # Persistir: resultado estructurado en estado + slot labs_parseados.
+    # Puente 2→3: calcular el Vigente Longevidad con estos labs (nivel B: se GUARDA
+    # en el estado, NO se expone al beta). El resultado ya viene "framed" (etiqueta,
+    # disclaimer, doble umbral). Best-effort: si falla, el labs_result igual se guarda.
+    indice = None
+    try:
+        from indice_vigente import compute_from_labs_result
+        # Si el estado ya tiene señales previas (wearable/cuestionario), súmalas.
+        prev = {}
+        try:
+            from state_persistence import load_state as _ls
+            prev = _ls(beta_id) or {}
+        except Exception:
+            pass
+        indice = compute_from_labs_result(
+            structured,
+            wearable=prev.get("wearable_result"),
+            cuestionario=prev.get("cuestionario_result"),
+        )
+    except Exception as e:
+        print(f"[labs_ingest] WARN compute_indice({beta_id}): {e}")
+
+    # Persistir: resultado estructurado + índice + slot labs_parseados (un solo save).
     try:
         from state_persistence import load_state, save_state, get_current_version
         state = load_state(beta_id) or {"beta_id": beta_id}
         state["labs_result"] = {**structured, "_ingested_at": _utc_now(),
                                 "_source_path": os.path.basename(pdf_path)}
+        if indice is not None:
+            state["indice_longevidad"] = indice  # nivel B — interno, no se muestra al beta
         try:
             save_state(beta_id, state, expected_version=get_current_version(beta_id) or 0)
         except Exception:

--- a/rag-bot/test_bridge_labs_indice.py
+++ b/rag-bot/test_bridge_labs_indice.py
@@ -1,0 +1,123 @@
+"""
+Puente 2→3: labs parseados → Vigente Longevidad (guardado en el state, nivel B).
+
+Cubre el mapeo de nombres crudos de labs MX → claves del Índice, la normalización de
+unidades (apoB g/L↔mg/dL), y el flujo end-to-end ingest_labs_pdf → state["indice_longevidad"]
+sin pegarle a OpenAI (mockeamos el parser).
+
+Run: python -m pytest rag-bot/test_bridge_labs_indice.py -q
+"""
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from indice_vigente import (
+    _parse_lab_value,
+    labs_result_to_longevidad_inputs,
+    compute_from_labs_result,
+)
+
+
+def _labs_result(markers):
+    return {"biomarkers": markers, "patient": {}, "lab": {}, "flags_critical": [], "notes": []}
+
+
+class TestParseValue(unittest.TestCase):
+    def test_variants(self):
+        self.assertEqual(_parse_lab_value("95 mg/dL"), 95.0)
+        self.assertEqual(_parse_lab_value("5,4"), 5.4)      # coma decimal MX
+        self.assertEqual(_parse_lab_value("<0.30"), 0.30)   # límite de detección
+        self.assertEqual(_parse_lab_value(88), 88.0)
+        self.assertIsNone(_parse_lab_value("no detectado"))
+
+
+class TestMapeoNombres(unittest.TestCase):
+    def test_nombres_mx_mapean(self):
+        lr = _labs_result([
+            {"name": "Glucosa", "value": "88", "unit": "mg/dL", "flag": "normal"},
+            {"name": "Hemoglobina glucosilada (HbA1c)", "value": "5,3", "unit": "%", "flag": "normal"},
+            {"name": "Triglicéridos", "value": "85", "unit": "mg/dL", "flag": "normal"},
+            {"name": "Proteína C reactiva ultrasensible", "value": "0.8", "unit": "mg/L", "flag": "normal"},
+            {"name": "Homocisteína", "value": "8", "unit": "µmol/L", "flag": "normal"},
+        ])
+        inp = labs_result_to_longevidad_inputs(lr)
+        self.assertEqual(inp["glucosa_ayuno"], 88.0)
+        self.assertEqual(inp["hba1c"], 5.3)
+        self.assertEqual(inp["trigliceridos"], 85.0)
+        self.assertEqual(inp["hs_crp"], 0.8)
+        self.assertEqual(inp["homocisteina"], 8.0)
+
+    def test_glucosa_postprandial_no_mapea(self):
+        lr = _labs_result([
+            {"name": "Glucosa postprandial 2h", "value": "140", "unit": "mg/dL", "flag": "normal"},
+        ])
+        self.assertNotIn("glucosa_ayuno", labs_result_to_longevidad_inputs(lr))
+
+    def test_apob_g_por_litro_se_convierte_a_mg_dl(self):
+        # 1.2 g/L = 120 mg/dL → debe cruzar umbral clínico (>100), NO puntuar como óptimo
+        lr = _labs_result([{"name": "Apolipoproteína B", "value": "1.2", "unit": "g/L", "flag": "high"}])
+        inp = labs_result_to_longevidad_inputs(lr)
+        self.assertEqual(inp["apob"], 120.0)
+        res = compute_from_labs_result(lr)
+        self.assertTrue(any(d["marcador"] == "apob" for d in res["derivaciones"]),
+                        "apoB 120 mg/dL debe disparar derivación, no puntuar óptimo")
+
+    def test_apob_mg_dl_se_respeta(self):
+        lr = _labs_result([{"name": "Apo B", "value": "75", "unit": "mg/dL", "flag": "normal"}])
+        self.assertEqual(labs_result_to_longevidad_inputs(lr)["apob"], 75.0)
+
+    def test_marcadores_irrelevantes_se_ignoran(self):
+        lr = _labs_result([{"name": "Colesterol LDL", "value": "100", "unit": "mg/dL", "flag": "normal"}])
+        self.assertEqual(labs_result_to_longevidad_inputs(lr), {})
+
+
+class TestComputeFromLabs(unittest.TestCase):
+    def test_end_to_end_framed(self):
+        lr = _labs_result([
+            {"name": "Glucosa", "value": "88", "unit": "mg/dL", "flag": "normal"},
+            {"name": "Apo B", "value": "70", "unit": "mg/dL", "flag": "normal"},
+        ])
+        res = compute_from_labs_result(lr)
+        self.assertFalse(res["es_diagnostico"])
+        self.assertIsNotNone(res["score"])
+        self.assertEqual(res["subscores"]["metabolico"], 100.0)
+
+
+class TestIngestBridge(unittest.TestCase):
+    """ingest_labs_pdf debe guardar state['indice_longevidad'] tras parsear (parser mockeado)."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        os.environ["HV_STATE_PERSISTENCE"] = "files"
+        os.environ["HV_BETA_STATES_DIR"] = self._tmp.name
+        os.environ["HV_TRACES_DIR"] = self._tmp.name
+        os.environ["HV_DECISION_LOG_ENABLED"] = "false"
+
+    def tearDown(self):
+        self._tmp.cleanup()
+        for k in ("HV_STATE_PERSISTENCE", "HV_BETA_STATES_DIR", "HV_TRACES_DIR"):
+            os.environ.pop(k, None)
+
+    def test_ingest_guarda_indice_en_state(self):
+        fake_structured = _labs_result([
+            {"name": "Glucosa", "value": "88", "unit": "mg/dL", "flag": "normal"},
+            {"name": "Apo B", "value": "70", "unit": "mg/dL", "flag": "normal"},
+        ])
+        fake_structured["extraction_method"] = "text"
+        import labs_ingest
+        with patch("scripts.labs_intake_manual.process_pdf", return_value=fake_structured), \
+             patch("scripts.labs_intake_manual.validate_labs_payload", return_value=[]):
+            r = labs_ingest.ingest_labs_pdf("wa-bridge-test", "/tmp/fake.pdf")
+        self.assertTrue(r["ok"])
+        # el índice quedó persistido en el estado, framed, sin exponerse en el reply
+        from state_persistence import load_state
+        st = load_state("wa-bridge-test") or {}
+        self.assertIn("indice_longevidad", st)
+        self.assertFalse(st["indice_longevidad"]["es_diagnostico"])
+        self.assertIsNotNone(st["indice_longevidad"]["score"])
+        self.assertNotIn(str(st["indice_longevidad"]["score"]), r.get("summary_text", ""))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rag-bot/test_labs_ingest.py
+++ b/rag-bot/test_labs_ingest.py
@@ -17,11 +17,14 @@ from whatsapp_channel import (
 )
 
 
+# Estructura REAL del parser (LABS_JSON_SCHEMA): key "biomarkers" + name/value/unit/flag.
+# (Antes este fixture usaba "biomarcadores"/nombre/valor — formato que el parser NO
+# produce — y ocultaba que labs_ingest leía la key equivocada.)
 _FAKE_LABS = {
-    "biomarcadores": [
-        {"nombre": "hs-CRP", "valor": 0.8, "unidad": "mg/L", "flag": "normal"},
-        {"nombre": "Glucosa", "valor": 110, "unidad": "mg/dL", "flag": "alto"},
-        {"nombre": "HbA1c", "valor": 5.9, "unidad": "%", "flag": "alto"},
+    "biomarkers": [
+        {"name": "hs-CRP", "value": "0.8", "unit": "mg/L", "flag": "normal"},
+        {"name": "Glucosa", "value": "110", "unit": "mg/dL", "flag": "high"},
+        {"name": "HbA1c", "value": "5.9", "unit": "%", "flag": "high"},
     ],
     "extraction_method": "text",
 }
@@ -90,13 +93,13 @@ class TestIngest(unittest.TestCase):
         state = load_state(self.beta)
         self.assertTrue((state.get("slots") or {}).get("labs_parseados"))
         self.assertIn("labs_result", state)
-        self.assertEqual(len(state["labs_result"]["biomarcadores"]), 3)
+        self.assertEqual(len(state["labs_result"]["biomarkers"]), 3)
 
     def test_no_markers_does_not_fill_slot(self):
         import labs_ingest
         from state_persistence import load_state
         with patch("scripts.labs_intake_manual.process_pdf",
-                   return_value={"biomarcadores": [], "extraction_method": "vision"}):
+                   return_value={"biomarkers": [], "extraction_method": "vision"}):
             r = labs_ingest.ingest_labs_pdf(self.beta, "/tmp/empty.pdf")
         self.assertFalse(r["ok"])
         state = load_state(self.beta) or {}


### PR DESCRIPTION
Conecta las piezas ya mergeadas (canal WhatsApp + parser de labs + Índice) en un **flujo real end-to-end**: el beta manda un PDF por el hilo → se parsea → **se calcula el Vigente Longevidad y se guarda en su estado** (nivel B: interno, NO se le muestra; el resultado viene *framed* con etiqueta/disclaimer/doble umbral).

## Puente (`indice_vigente.py`)
- `labs_result_to_longevidad_inputs()`: mapea nombres crudos de labs mexicanos → claves del Índice por sinónimos (glucosa/HbA1c/ApoB/triglicéridos/hs-CRP/homocisteína), **excluye glucosa postprandial**, y **normaliza unidades** (apoB en g/L → mg/dL) para que el doble umbral clínico no se salte por un tema de unidad.
- `compute_from_labs_result()`: atajo `structured` del parser → Índice *framed*.
- `labs_ingest`: calcula y guarda `state["indice_longevidad"]` en el mismo save (best-effort; si falla, el `labs_result` igual se persiste).

## 🐛 Bug latente arreglado (descubierto al construir el puente)
El parser (`LABS_JSON_SCHEMA`) emite la key **`biomarkers`** (inglés), pero `labs_ingest` leía `biomarcadores`/`markers` → **con labs reales habría dado `n=0` siempre** ("no detecté biomarcadores"). El test de la pieza 2 lo ocultaba mockeando con la key en español. Corregido: `labs_ingest` lee la key real, y el test viejo ahora usa la estructura real del parser (`biomarkers` + `name/value/unit/flag`).

## Verificación
8 tests nuevos del puente (mapeo, unidades apoB, postprandial, end-to-end ingest→state) + `test_labs_ingest` alineado a la realidad del parser. Gate completo **81 passed**.

## Nivel de exposición (sin cambios respecto a lo acordado)
Nivel B: el Índice **se guarda** en el estado del beta, **no se le muestra**. Promover a cara-al-usuario sigue siendo flag + visto bueno COFEPRIS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)