### PR TITLE
fix(golden): nightly verde — routing 'lounge' + fragmentos reales P-001/P-002

### DIFF
--- a/rag-bot/data/golden-set-hv-rag.json
+++ b/rag-bot/data/golden-set-hv-rag.json
@@ -623,12 +623,14 @@
       "topic": "auto-promoted",
       "mode": "retrieval",
       "expected_traits": [
-        "kb_route servicios",
-        "source o answer menciona fragmento de la respuesta promovida"
+        "kb_route servicios (con hint 'lounge')",
+        "source o answer menciona fragmento de la respuesta promovida (horario)"
       ],
       "parsed": {
         "must_contain_any": [
-          "source o answer menciona fragmento de la respuesta promovida"
+          "por cita",
+          "9-20",
+          "Lun"
         ],
         "must_not_contain": [],
         "expected_gate": null,
@@ -697,17 +699,19 @@
       "topic": "auto-promoted",
       "mode": "retrieval",
       "expected_traits": [
-        "kb_route servicios",
-        "source o answer menciona fragmento de la respuesta promovida"
+        "kb_route all (FAQ de pago/logística, no específica de servicio; se responde desde FAQ_PROMOTED en cualquier ruta)",
+        "source o answer menciona fragmento de la respuesta promovida (AMEX)"
       ],
       "parsed": {
         "must_contain_any": [
-          "source o answer menciona fragmento de la respuesta promovida"
+          "AMEX",
+          "American Express",
+          "Mastercard"
         ],
         "must_not_contain": [],
         "expected_gate": null,
         "no_gate": false,
-        "expected_route": "servicios",
+        "expected_route": "all",
         "expected_gate_path": null,
         "expected_gate_path_any": null
       },

--- a/rag-bot/rag_retrieval_local.py
+++ b/rag-bot/rag_retrieval_local.py
@@ -61,7 +61,7 @@ LLM_MODEL = "gpt-4o-mini"
 SERVICIOS_HINTS = re.compile(
     r"\b(hifu|botox|fillers?|sculptra|rf\s*microneedling|láser|laser|depilación|"
     r"corte|barba|manicure|pedicure|blanqueamiento|limpieza facial|precio|cuesta|"
-    r"sesión|sesiones|servicio|clínica estética)\b",
+    r"sesión|sesiones|servicio|clínica estética|lounge)\b",
     re.I,
 )
 LONGEVITY_HINTS = re.compile(


### PR DESCRIPTION
El **nightly (`golden_runner.py --full`) llevaba días rojo** — no por el índice ni los servicios, sino por 2 casos golden P1 (`P-001`/`P-002`, FAQ auto-promovida) con expectativas mal definidas. Dos bugs en cascada:

## 1. Routing
- `lounge` no estaba en `SERVICIOS_HINTS` → "¿Horario del lounge?" ruteaba a `all`. **Agregado el hint** → rutea a `servicios` (semánticamente correcto: el lounge es el venue de servicios).
- "aceptan amex" es pago genérico, no servicio-específico → **expectativa corregida a `all`** (se responde desde FAQ_PROMOTED en cualquier ruta).

## 2. Trait de contenido (el bug real)
`must_contain_any` tenía la **descripción del trait** (`"source o answer menciona fragmento de la respuesta promovida"`) en vez de un **fragmento real** → reemplazado por fragmentos de la respuesta promovida que SÍ existe en `FAQ_PROMOTED.md`:
- P-001 → `por cita` / `9-20` / `Lun` (de "Lun-Sáb 9-20h por cita")
- P-002 → `AMEX` / `American Express` / `Mastercard`

## Verificación
- `golden --full`: **29/29** (antes 27/29), con índice fresco + key real.
- Routing offline: lounge→servicios, amex→all, HIFU→servicios, NMN→longevity (sin regresión).
- Gate por-PR `test_rag_local`: 19 passed.

**Contexto**: el contenido/índice del SSOT nunca estuvo mal — solo las expectativas del golden. Un nightly verde vuelve a hacer visibles regresiones reales (un job crónicamente rojo las escondía).

🤖 Generated with [Claude Code](https://claude.com/claude-code)