### PR TITLE
feat(supply): vendor_quality — criterio de proveedor Av.2 como código

### DIFF
--- a/.github/workflows/rag-bot-ci.yml
+++ b/.github/workflows/rag-bot-ci.yml
@@ -56,6 +56,7 @@ jobs:
             test_newsletter_approval.py \
             test_c1_idempotency.py \
             test_whatsapp_channel.py \
+            test_vendor_quality.py \
             test_indice_vigente.py \
             test_bridge_labs_indice.py \
             test_onboarding_flow.py \

--- a/rag-bot/data/vendor_quality.json
+++ b/rag-bot/data/vendor_quality.json
@@ -1,0 +1,18 @@
+{
+  "_doc": "Registro de proveedores Av.2 (péptidos/viales). SSOT de decisiones de calidad de suministro. Llenar al evaluar cada vendor. Ver estrategia_2026/Calidad_Suministro_Peptidos.md. Evaluar: python vendor_quality.py",
+  "vendors": [
+    {
+      "name": "Exoma",
+      "inyectable": true,
+      "en_finnrick": false,
+      "finnrick_ok": null,
+      "en_janoshik": false,
+      "coa_por_lote": true,
+      "endotoxinas": null,
+      "esterilidad": null,
+      "iso_17025_lab": false,
+      "ultimo_lote_testeado": null,
+      "notas": "MX (Monterrey). Dice '99% HPLC' pero no aparece en testeo independiente → no verificable. Criba falla."
+    }
+  ]
+}

--- a/rag-bot/data/vendor_quality.json
+++ b/rag-bot/data/vendor_quality.json
@@ -1,6 +1,72 @@
 {
   "_doc": "Registro de proveedores Av.2 (péptidos/viales). SSOT de decisiones de calidad de suministro. Llenar al evaluar cada vendor. Ver estrategia_2026/Calidad_Suministro_Peptidos.md. Evaluar: python vendor_quality.py",
+  "_provenance": "Datos de criba (en_finnrick/finnrick_ok/ratings) de recon Finnrick ~2026-06. Re-verificar: un ranking NO abre el gate — exige lote testeado + COA + firma médico. coa_por_lote/endotoxinas/esterilidad = null/false hasta confirmar con el vendor; ultimo_lote_testeado = null hasta mandar muestra.",
   "vendors": [
+    {
+      "name": "Peptide Partners",
+      "inyectable": true,
+      "en_finnrick": true,
+      "finnrick_ok": true,
+      "en_janoshik": null,
+      "coa_por_lote": false,
+      "endotoxinas": null,
+      "esterilidad": null,
+      "iso_17025_lab": false,
+      "ultimo_lote_testeado": null,
+      "notas": "Finnrick A→C · 7 prod · 74 tests · avg 8.2 (min 4.2) · últ. 2026-05-08. Mejor balance amplitud/calidad de la criba. Falta: confirmar COA por lote + endotoxinas/esterilidad + testear lote."
+    },
+    {
+      "name": "Andy Peps Studio",
+      "inyectable": true,
+      "en_finnrick": true,
+      "finnrick_ok": true,
+      "en_janoshik": null,
+      "coa_por_lote": false,
+      "endotoxinas": null,
+      "esterilidad": null,
+      "iso_17025_lab": false,
+      "ultimo_lote_testeado": null,
+      "notas": "Finnrick A→B · 3 prod · 31 tests · avg 8.4 (min 6.0). El más consistente lote-a-lote (su peor lote no baja de 6). Poca variedad. Falta calificación + verificación de lote."
+    },
+    {
+      "name": "Polaris Peptides",
+      "inyectable": true,
+      "en_finnrick": true,
+      "finnrick_ok": true,
+      "en_janoshik": null,
+      "coa_por_lote": false,
+      "endotoxinas": null,
+      "esterilidad": null,
+      "iso_17025_lab": false,
+      "ultimo_lote_testeado": null,
+      "notas": "Finnrick A→D · 9 prod · 99 tests · avg 7.3 (min 3.9) · desde dic-2024. Máxima amplitud con volumen; dispersión hasta D → exige COA por lote estricto. Falta calificación + verificación."
+    },
+    {
+      "name": "Paradigm Peptide",
+      "inyectable": true,
+      "en_finnrick": true,
+      "finnrick_ok": true,
+      "en_janoshik": null,
+      "coa_por_lote": false,
+      "endotoxinas": null,
+      "esterilidad": null,
+      "iso_17025_lab": false,
+      "ultimo_lote_testeado": null,
+      "notas": "Finnrick A puro · 2 prod · 18 tests · avg 8.8. Máxima pureza, poca variedad — usar si necesitas 1-2 péptidos premium. Falta calificación + verificación de lote."
+    },
+    {
+      "name": "HK Peptides",
+      "inyectable": true,
+      "en_finnrick": true,
+      "finnrick_ok": false,
+      "en_janoshik": null,
+      "coa_por_lote": false,
+      "endotoxinas": null,
+      "esterilidad": null,
+      "iso_17025_lab": false,
+      "ultimo_lote_testeado": null,
+      "notas": "Finnrick A→E · 13 prod · 421 tests · min 0.0. Catálogo gigante pero con lotes que puntúan 0 (finnrick_ok=false: resultados NO uniformemente aceptables). Solo con COA por lote + testeo estricto de cada lote; alto riesgo."
+    },
     {
       "name": "Exoma",
       "inyectable": true,
@@ -12,7 +78,7 @@
       "esterilidad": null,
       "iso_17025_lab": false,
       "ultimo_lote_testeado": null,
-      "notas": "MX (Monterrey). Dice '99% HPLC' pero no aparece en testeo independiente → no verificable. Criba falla."
+      "notas": "MX (Monterrey). Dice '99% HPLC' pero no aparece en testeo independiente (Finnrick/Janoshik) → no verificable. Criba falla."
     }
   ]
 }

--- a/rag-bot/test_vendor_quality.py
+++ b/rag-bot/test_vendor_quality.py
@@ -1,0 +1,88 @@
+"""Tests del criterio de selección de proveedor (Av.2). Sin red — pura lógica."""
+import unittest
+from datetime import datetime, timezone, timedelta
+
+from vendor_quality import Vendor, evaluate, _criba
+
+
+def _ago(days):
+    return (datetime.now(timezone.utc) - timedelta(days=days)).isoformat()
+
+
+class TestCriba(unittest.TestCase):
+    def test_finnrick_ok_es_fuerte(self):
+        c = _criba(Vendor("X", en_finnrick=True, finnrick_ok=True))
+        self.assertTrue(c["pass"]); self.assertEqual(c["fuerza"], "fuerte")
+
+    def test_finnrick_fallido_descarta(self):
+        c = _criba(Vendor("X", en_finnrick=True, finnrick_ok=False))
+        self.assertFalse(c["pass"]); self.assertEqual(c["fuerza"], "negativa")
+
+    def test_janoshik_solo_es_debil_no_suficiente(self):
+        c = _criba(Vendor("X", en_janoshik=True))
+        self.assertTrue(c["pass"]); self.assertEqual(c["fuerza"], "debil")
+
+    def test_sin_testeo_independiente_falla(self):
+        c = _criba(Vendor("Exoma"))
+        self.assertFalse(c["pass"]); self.assertEqual(c["fuerza"], "nula")
+
+
+class TestGate(unittest.TestCase):
+    def _full(self, **kw):
+        base = dict(
+            name="V", inyectable=True, en_finnrick=True, finnrick_ok=True,
+            coa_por_lote=True, endotoxinas=True, esterilidad=True,
+            ultimo_lote_testeado={"lab": "MZ Biolabs", "fecha": _ago(30), "lote": "L1", "resultado": "pass"},
+        )
+        base.update(kw)
+        return evaluate(Vendor(**base))
+
+    def test_proveedor_completo_pasa_gate(self):
+        self.assertTrue(self._full()["gate_av2"])
+
+    def test_buen_ranking_sin_lote_testeado_NO_pasa(self):
+        # El núcleo del criterio: ranking ≠ confianza. Sin test de lote, no hay gate.
+        r = self._full(ultimo_lote_testeado=None)
+        self.assertFalse(r["gate_av2"])
+        self.assertTrue(any("verificación" in f for f in r["faltantes"]))
+
+    def test_inyectable_sin_endotoxinas_NO_pasa(self):
+        r = self._full(endotoxinas=False)
+        self.assertFalse(r["gate_av2"])
+        self.assertTrue(any("endotoxinas" in f for f in r["faltantes"]))
+
+    def test_lote_viejo_no_pasa(self):
+        r = self._full(ultimo_lote_testeado={"lab": "Janoshik", "fecha": _ago(400), "lote": "L9", "resultado": "pass"})
+        self.assertFalse(r["gate_av2"])
+
+    def test_lote_fallido_no_pasa(self):
+        r = self._full(ultimo_lote_testeado={"lab": "ACS", "fecha": _ago(10), "lote": "L2", "resultado": "fail"})
+        self.assertFalse(r["gate_av2"])
+
+    def test_janoshik_como_lab_de_verificacion_es_valido(self):
+        # Janoshik vale como DESTINO de muestra (paso 3), aunque sea débil como fuente.
+        r = self._full(en_finnrick=False, finnrick_ok=None, en_janoshik=True,
+                       ultimo_lote_testeado={"lab": "Janoshik", "fecha": _ago(5), "lote": "L3", "resultado": "pass"})
+        # criba débil pero los 3 pasos en verde → gate abre (con nota de criba débil)
+        self.assertTrue(r["verificacion"]["pass"])
+
+    def test_no_inyectable_no_exige_endotoxinas(self):
+        r = self._full(inyectable=False, endotoxinas=None, esterilidad=None)
+        self.assertTrue(r["gate_av2"])
+
+
+class TestRegistry(unittest.TestCase):
+    def test_exoma_seed_falla_criba(self):
+        import os, json, tempfile
+        from vendor_quality import evaluate_registry
+        # usa el registro real del repo (Exoma seed)
+        from vendor_quality import load_registry
+        vendors = {v.name: v for v in load_registry()}
+        if "Exoma" in vendors:
+            r = evaluate(vendors["Exoma"])
+            self.assertFalse(r["gate_av2"])
+            self.assertFalse(r["criba"]["pass"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rag-bot/vendor_quality.py
+++ b/rag-bot/vendor_quality.py
@@ -1,0 +1,170 @@
+"""
+vendor_quality.py — Criterio de selección de proveedor (Av.2) como CÓDIGO.
+
+Convierte el embudo de Calidad_Suministro_Peptidos.md en una rúbrica ejecutable.
+NO scrapea: tú alimentas los datos (data/vendor_quality.json); esto puntúa y decide.
+
+Embudo de 3 pasos:
+  1. CRIBA        — ¿se somete a testeo independiente? (Finnrick fuerte; Janoshik débil)
+  2. CALIFICACIÓN — COA por lote (+ endotoxinas/esterilidad si inyectable)
+  3. VERIFICACIÓN — el LOTE que vas a usar fue testeado (no negociable)
+
+Principio rector: un buen ranking NO sustituye testear el lote. Por eso la criba
+sola nunca abre el gate Av.2; los 3 pasos + firma del médico (externa) lo hacen.
+
+Ref: estrategia_2026/Calidad_Suministro_Peptidos.md · rag-bot/docs/AI_Second_Opinion_Spec.md
+
+AUTO-FETCH (diferido — recon 2026-06, robots.txt):
+  - Finnrick: robots PERMITE público (invita a crawlers IA), pero DISALLOW /api/.
+    Si algún día auto-fetcheas: "Researcher data access" (legítimo) > páginas públicas
+    (Next.js server-rendered → fetch+Cheerio, sin headless). Nunca /api/.
+  - Janoshik: robots PROHÍBE bots (ai-train=no). NO scrapear; usar solo como LAB
+    (destino de muestra, paso 3), no como fuente de datos.
+  Hoy: el registro se llena a mano (este archivo no hace red). Construir auto-fetch
+  solo cuando evalúes vendors de forma recurrente (Av.2 a escala).
+"""
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass, field, asdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+# Días tras los cuales un test de lote se considera viejo (re-testear).
+LOTE_TEST_TTL_DIAS = 365
+
+
+@dataclass
+class Vendor:
+    name: str
+    inyectable: bool = False               # inyectable → exige endotoxinas + esterilidad
+    # Paso 1 — criba (fuentes de ranking)
+    en_finnrick: Optional[bool] = None     # independiente → señal FUERTE
+    finnrick_ok: Optional[bool] = None     # resultados aceptables en Finnrick
+    en_janoshik: Optional[bool] = None     # vendor-submitted → señal DÉBIL (sesgo selección)
+    # Paso 2 — calificación (por vendor)
+    coa_por_lote: bool = False
+    endotoxinas: Optional[bool] = None     # solo aplica si inyectable
+    esterilidad: Optional[bool] = None     # solo aplica si inyectable
+    iso_17025_lab: bool = False            # bonus de rigor
+    # Paso 3 — verificación (por lote)
+    ultimo_lote_testeado: Optional[Dict[str, Any]] = None  # {lab, fecha, lote, resultado}
+    notas: str = ""
+
+
+def _dias_desde(fecha_iso: Optional[str]) -> Optional[int]:
+    if not fecha_iso:
+        return None
+    try:
+        f = datetime.fromisoformat(str(fecha_iso).replace("Z", "+00:00"))
+        return (datetime.now(timezone.utc) - f).days
+    except Exception:
+        return None
+
+
+def _criba(v: Vendor) -> Dict[str, Any]:
+    """Paso 1: ¿se somete a testeo independiente? Finnrick fuerte; Janoshik débil; nada → fail."""
+    if v.en_finnrick and v.finnrick_ok:
+        return {"pass": True, "fuerza": "fuerte", "razon": "Finnrick independiente con resultados OK"}
+    if v.en_finnrick and v.finnrick_ok is False:
+        return {"pass": False, "fuerza": "negativa", "razon": "Finnrick con resultados fallidos → descartar"}
+    if v.en_janoshik:
+        return {"pass": True, "fuerza": "debil",
+                "razon": "Solo Janoshik (vendor-submitted, sesgo de selección) — no suficiente para confiar"}
+    return {"pass": False, "fuerza": "nula", "razon": "No aparece en testeo independiente (ej. Exoma)"}
+
+
+def _calificacion(v: Vendor) -> Dict[str, Any]:
+    """Paso 2: COA por lote (+ endotoxinas/esterilidad si inyectable)."""
+    faltantes: List[str] = []
+    if not v.coa_por_lote:
+        faltantes.append("COA por lote")
+    if v.inyectable:
+        if not v.endotoxinas:
+            faltantes.append("prueba de endotoxinas (inyectable)")
+        if not v.esterilidad:
+            faltantes.append("prueba de esterilidad (inyectable)")
+    return {"pass": not faltantes, "faltantes": faltantes, "iso_17025": v.iso_17025_lab}
+
+
+def _verificacion(v: Vendor) -> Dict[str, Any]:
+    """Paso 3: el lote a usar fue testeado por un lab independiente y está vigente."""
+    lote = v.ultimo_lote_testeado or {}
+    if not lote.get("lab"):
+        return {"pass": False, "razon": "Sin test de lote — NO usar en protocolo Av.2"}
+    dias = _dias_desde(lote.get("fecha"))
+    if dias is not None and dias > LOTE_TEST_TTL_DIAS:
+        return {"pass": False, "razon": f"Test de lote viejo ({dias}d > {LOTE_TEST_TTL_DIAS}d) — re-testear"}
+    if str(lote.get("resultado", "")).lower() in ("fail", "fallo", "rechazado"):
+        return {"pass": False, "razon": "El lote testeado FALLÓ → descartar lote"}
+    return {"pass": True, "razon": f"Lote {lote.get('lote','?')} testeado en {lote.get('lab')}"}
+
+
+def evaluate(v: Vendor) -> Dict[str, Any]:
+    """
+    Aplica el embudo. gate_av2 = los 3 pasos en verde. La firma del médico responsable
+    es un paso EXTERNO (no automatizable): gate_av2=True habilita la decisión, no la sustituye.
+    """
+    criba = _criba(v)
+    cal = _calificacion(v)
+    ver = _verificacion(v)
+    gate = bool(criba["pass"] and cal["pass"] and ver["pass"])
+
+    faltantes: List[str] = []
+    if not criba["pass"]:
+        faltantes.append(f"criba: {criba['razon']}")
+    elif criba["fuerza"] == "debil":
+        faltantes.append("criba débil (solo Janoshik) — preferir un vendor con historial en Finnrick")
+    faltantes += [f"calificación: falta {x}" for x in cal["faltantes"]]
+    if not ver["pass"]:
+        faltantes.append(f"verificación: {ver['razon']}")
+
+    return {
+        "vendor": v.name,
+        "inyectable": v.inyectable,
+        "criba": criba,
+        "calificacion": cal,
+        "verificacion": ver,
+        "gate_av2": gate,
+        "faltantes": faltantes,
+        "siguiente_paso": (
+            "Listo para decisión del médico responsable (firma)" if gate
+            else (faltantes[0] if faltantes else "revisar")
+        ),
+    }
+
+
+# ------------------------------------------------------------------
+# Registro (data/vendor_quality.json) — SSOT de decisiones de proveedor
+# ------------------------------------------------------------------
+
+def _registry_path() -> Path:
+    return Path(os.getenv("HV_VENDOR_REGISTRY", "data/vendor_quality.json"))
+
+
+def load_registry() -> List[Vendor]:
+    p = _registry_path()
+    if not p.exists():
+        return []
+    raw = json.loads(p.read_text(encoding="utf-8"))
+    items = raw.get("vendors", raw) if isinstance(raw, dict) else raw
+    return [Vendor(**{k: v for k, v in d.items() if k in Vendor.__dataclass_fields__}) for d in items]
+
+
+def evaluate_registry() -> List[Dict[str, Any]]:
+    return [evaluate(v) for v in load_registry()]
+
+
+if __name__ == "__main__":
+    import sys
+    results = evaluate_registry()
+    if not results:
+        print("Registro vacío. Crea data/vendor_quality.json con {\"vendors\":[...]}.")
+        sys.exit(0)
+    for r in results:
+        estado = "✅ gate Av.2 OK (→ firma médico)" if r["gate_av2"] else "⛔ no pasa"
+        print(f"\n{r['vendor']} {'(inyectable)' if r['inyectable'] else ''} — {estado}")
+        for f in r["faltantes"]:
+            print(f"   • {f}")

--- a/rag-bot/vendor_quality.py
+++ b/rag-bot/vendor_quality.py
@@ -22,6 +22,16 @@ AUTO-FETCH (diferido — recon 2026-06, robots.txt):
     (destino de muestra, paso 3), no como fuente de datos.
   Hoy: el registro se llena a mano (este archivo no hace red). Construir auto-fetch
   solo cuando evalúes vendors de forma recurrente (Av.2 a escala).
+
+CONTRATO Finnrick (para el fetcher futuro — recon, confirmado en HTML server-rendered):
+  L1 /vendors            → {vendorName, slug, ratingRange, productsCount, testCount,
+                            avgScore, minScore, maxScore, oldestTest, mostRecentTest}
+                            → mapea a en_finnrick + finnrick_ok (avg/min/ratingRange).
+  L2 /vendors/{slug}     → products[]{productName, rating, count, avg, min, max} + recentTests[]
+  L3 recentTests/batch   → {product, score, testDate, batchId, lab, purity, dosage,
+                            endotoxins, coaUrl} → mapea a ultimo_lote_testeado + endotoxinas.
+  Extracción: __NEXT_DATA__ (JSON embebido) o /_next/data/{buildId}/vendors/{slug}.json;
+  fallback fetch+Cheerio. NUNCA /api/ (robots disallow). Janoshik: PDFs por lote (OCR), sin tabla.
 """
 from __future__ import annotations
 


### PR DESCRIPTION
Responde tu "¿por qué no construir algo?" — construye **el criterio de selección de proveedor como código**, no el scraper (eso queda diferido con datos, no corazonada).

## Qué es
`vendor_quality.py`: rúbrica ejecutable del embudo de `Calidad_Suministro_Peptidos.md`, alimentada por `data/vendor_quality.json` (tú metes los datos al evaluar; **no toca la red**).

**Embudo en código** (criba → calificación → verificación por lote):
- **Criba**: Finnrick = señal **fuerte** (independiente); Janoshik = **débil** (vendor-submitted, sesgo) — nunca pasa solo; sin testeo indep → falla (ej. Exoma).
- **Calificación**: COA por lote (+ endotoxinas/esterilidad si inyectable).
- **Verificación**: el **lote** que usarás, testeado y vigente. **El núcleo del criterio**: un buen ranking NO abre el gate sin lote testeado.
- **gate_av2** = los 3 pasos → habilita la decisión; la firma del médico es paso externo.

## Janoshik (tu pregunta)
Doble papel: **débil como fuente** (campo `en_janoshik`, peso bajo) pero **válido como lab** de verificación (paso 3). Codificado así.

## Recon de auto-fetch (robots.txt, anotada — diferido)
- **Finnrick**: permite público (invita a IA), bloquea `/api/` → fetcheable vía "Researcher access" o páginas públicas (Cheerio), nunca `/api/`.
- **Janoshik**: prohíbe bots → **no scrapear**, usar solo como lab.

## Verificación
12 tests (incl. "buen ranking sin lote testeado NO pasa", "inyectable sin endotoxinas NO pasa", "Janoshik como lab válido"), cableados a `rag-bot-ci`. Gate local 38 passed. Seed Exoma → ⛔ falla criba.

🤖 Generated with [Claude Code](https://claude.com/claude-code)