### PR TITLE
fix(newsletter): preview email omitido por PULSO_MODE=shadow

### DIFF
--- a/.github/workflows/newsletter-draft.yml
+++ b/.github/workflows/newsletter-draft.yml
@@ -111,6 +111,9 @@ jobs:
       - name: Aprobación — preview por correo + issue GitHub
         if: steps.pr.outputs.pull-request-number != ''
         env:
+          # Override del PULSO_MODE: shadow del job — el preview SÍ debe enviar el
+          # correo real al owner (Fase A). El shadow del job solo aplica al ensayo/post-mortem.
+          PULSO_MODE: production
           RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
           NEWSLETTER_FROM: ${{ vars.NEWSLETTER_FROM }}
           NEWSLETTER_APPROVAL_TO: ${{ vars.NEWSLETTER_APPROVAL_TO }}


### PR DESCRIPTION
## La causa real de "sigue sin funcionar"
El log de `newsletter-draft` lo confirmó: `PULSO_MODE=shadow — preview email omitido`.

El workflow corre con `PULSO_MODE: shadow` a **nivel job** (correcto para el paso de ensayo/post-mortem), pero ese flag **se filtraba al paso de preview** → `approval.py send-preview` omitía el correo. Resultado: cada jueves se generaba el draft, se abría el PR, se creaba el issue… **pero el borrador nunca llegaba a tu inbox.** Por eso parecía "no funciona" aunque los workflows salían verdes.

## Fix
Override `PULSO_MODE: production` **solo en el paso de preview por correo**. El ensayo del job sigue en shadow (no envía de más). `newsletter-send.yml` no tiene este gag → el envío a suscriptores (tras tu aprobación) estaba intacto.

## Lo que ya estaba bien (no era esto)
- Toggle de PRs (fix previo) ✓ · harvest Europe PMC ✓ · dominio Resend `hombrevigente.com` verificado ✓ · modelo Claude (#50) ✓.

## Tras mergear
Re-disparar `newsletter-draft` → ahora SÍ te llega el correo "[BORRADOR Pulso NºNNN]" para aprobar.

Heads-up aparte: tu `newsletter/.env` **local** tiene `NEWSLETTER_FROM` pegado con `ANTHROPIC_API_KEY` (falta salto de línea) — rompe runs locales; Actions usa los GH secrets, así que no afecta prod. Conviene corregirlo a mano.

🤖 Generated with [Claude Code](https://claude.com/claude-code)