### PR TITLE
fix(newsletter): aprobar no enviaba (merge por GITHUB_TOKEN no dispara send)

### DIFF
--- a/.github/workflows/newsletter-approval.yml
+++ b/.github/workflows/newsletter-approval.yml
@@ -146,6 +146,22 @@ jobs:
             gh pr merge "$PR" --merge --delete-branch
           fi
 
+      - name: Enviar a Plus (Resend)
+        # El merge anterior usa GITHUB_TOKEN → NO dispara newsletter-send.yml
+        # (GitHub no encadena workflows en pushes del token). Por eso enviamos
+        # aquí directo. send.py gatea por approved:true (ya marcado arriba).
+        if: steps.parse.outputs.action == 'approve'
+        env:
+          RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
+          RESEND_AUDIENCE_PLUS: ${{ vars.RESEND_AUDIENCE_PLUS }}
+          RESEND_AUDIENCE_FREE: ${{ vars.RESEND_AUDIENCE_FREE }}
+          NEWSLETTER_FROM: ${{ vars.NEWSLETTER_FROM }}
+        run: |
+          if [ -z "${RESEND_API_KEY:-}" ]; then
+            echo "RESEND_API_KEY no configurado — envío omitido (sin error)."; exit 0
+          fi
+          python newsletter/send.py "${{ steps.parse.outputs.issue_path }}"
+
       - name: Cerrar issue aprobación
         if: steps.parse.outputs.action == 'approve' && github.event_name == 'issue_comment'
         env:


### PR DESCRIPTION
## "Aprobé y nada" — causa raíz
La aprobación **sí funcionó** (run `repository_dispatch` success, issue cerrado, PR #51 mergeado, `approved:true`). Pero **`newsletter-send` nunca disparó** (cero runs el 26-jun).

Motivo: el workflow de aprobación mergea el PR con `gh pr merge` (GITHUB_TOKEN), y **GitHub no encadena workflows en pushes hechos por el GITHUB_TOKEN** (anti-recursión). Así, el push a `main` que debía gatillar `newsletter-send.yml` se ignoró → se cerró el issue diciendo "enviado a Plus" pero no salió nada.

## Fix
Nuevo paso **"Enviar a Plus"** en el propio `newsletter-approval.yml`, tras el merge: llama `send.py` directo (mismo código que `newsletter-send.yml` usó para Nº002). Gateado por `approved:true` (ya marcado) + `RESEND_API_KEY`. Ya no depende del trigger por merge.

## Cadena completa de fixes de esta saga (para contexto)
1. Toggle de PRs `false` → draft no abría PR.
2. Modelo Claude stale (404) → compose en fallback (#50).
3. `PULSO_MODE=shadow` → correo de preview omitido (#56).
4. **Este**: merge por GITHUB_TOKEN no dispara el envío.

Tras mergear, la próxima aprobación envía de verdad a la audiencia Plus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)