### PR TITLE
fix(newsletter): envío idempotente entre runs (Nº004 duplicado)

### DIFF
--- a/.github/workflows/newsletter-approval.yml
+++ b/.github/workflows/newsletter-approval.yml
@@ -156,6 +156,14 @@ jobs:
             echo "RESEND_API_KEY no configurado — envío omitido (sin error)."; exit 0
           fi
           python newsletter/send.py "${{ steps.parse.outputs.issue_path }}"
+          # PERSISTIR el registro de envío (sent_at/broadcast_id en approvals/NNN.json)
+          # para que otra aprobación del mismo número NO reenvíe. send.py ya lo lee con
+          # _already_sent; el bug era que el registro vivía solo en el runner efímero.
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add newsletter/approvals/ 2>/dev/null || true
+          git commit -m "chore(newsletter): registro de envío $(basename "${{ steps.parse.outputs.issue_path }}" .md)" || true
+          git push origin "${{ steps.branch.outputs.branch }}" || true
 
       # Housekeeping: mergear el borrador a main (para que la numeración avance).
       # NO-FATAL: si el merge choca (base modificada), el envío ya ocurrió arriba.

--- a/newsletter/approvals/004.json
+++ b/newsletter/approvals/004.json
@@ -3,5 +3,7 @@
   "issue_path": "newsletter/issues/2026-06-004.md",
   "github_issue": 60,
   "pr": 59,
-  "status": "pending"
+  "status": "sent",
+  "sent_at": "2026-06-26T23:48:23Z",
+  "broadcast_id": "e8537d26-d228-4bf2-96f2-ed142c283202"
 }


### PR DESCRIPTION
## Causa del Nº004 duplicado
Se aprobó **dos veces**: mi dispatch del 26-jun (envío #1) + tú clicaste el botón del correo el 29-jun (envío #2, run repository_dispatch). `send.py` reenvió porque su guard `_already_sent` lee `approvals/NNN.json`, pero **ese registro nunca se persistía** — vivía solo en el runner efímero, y el `git stash -u` del paso de merge lo descartaba.

## Fix (2 partes)
1. **Workflow**: el paso "Enviar a Plus" ahora **commitea + pushea `approvals/NNN.json`** (con `sent_at`/`broadcast_id`) tras enviar. La próxima aprobación del mismo número ve `sent_at` → omite. (El `git merge origin/main -X theirs` del checkout hace que main gane → el registro persiste de verdad.) Combinado con el `concurrency: pulso-approval` de #61, no hay reenvíos ni por dual-canal ni por re-aprobación.
2. **Backfill `approvals/004.json`**: `status: sent` + `sent_at` + `broadcast_id` real → Nº004 **blindado ya** contra un tercer envío.

## Daño previo
2 copias del Nº004 ya salieron (irreversible). Esto previene la 3ª y todas las futuras.

🤖 Generated with Claude Code