### PR TITLE
chore: ignorar data/ raíz y clon anidado

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,12 @@ node_modules/
 /build
 /out
 
+# === Datos runtime en raíz (decision_log, pending_actions del agente local) ===
+/data/
+
+# === Clones locales de trabajo (repos anidados) ===
+/hombrevigente-fresh/
+
 # === MVP-0 datos clínicos (PHI — nunca en git) ===
 rag-bot/data/labs_intake/
 rag-bot/data/intake/


### PR DESCRIPTION
Hallazgo de la auditoría general: `data/` en la raíz (logs runtime del agente) y `hombrevigente-fresh/` (clon anidado) no estaban en `.gitignore` — un `git add .` los commitearía por accidente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)