### PR TITLE
chore: ignorar rag-bot/data/traces/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ rag-bot/data/labs_intake/
 rag-bot/data/intake/
 rag-bot/data/protocols/
 rag-bot/data/mvp0_runs/
+rag-bot/data/traces/
 
 # === RAG / Vector DBs ===
 qdrant_storage/


### PR DESCRIPTION
Seguimiento de #65 — traces del agente (jsonl runtime) también estaban sin ignorar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)