### PR TITLE
feat(rag-bot): memoria episódica en Postgres SSOT (hv_decision_log)

### DIFF
--- a/.github/workflows/rag-bot-ci.yml
+++ b/.github/workflows/rag-bot-ci.yml
@@ -60,7 +60,8 @@ jobs:
             test_indice_vigente.py \
             test_bridge_labs_indice.py \
             test_onboarding_flow.py \
-            test_labs_ingest.py
+            test_labs_ingest.py \
+            test_decision_log_pg.py
 
       - name: Golden set (gates-only)
         run: python golden_runner.py --gates-only

--- a/rag-bot/decision_log.py
+++ b/rag-bot/decision_log.py
@@ -1,5 +1,10 @@
 """
 Audit trail de decisiones RAG — patrón CMU agent-decision-log.ts (fail-open JSONL).
+
+Dual-write (migración 004): además del JSONL local, cada decisión se inserta
+best-effort en hv_decision_log (Postgres SSOT). La lectura prefiere Postgres
+cuando está configurado — así knowledge gaps ve TODAS las máquinas, no solo
+el volumen local. Un `path` explícito fuerza modo archivo (tests, tooling).
 """
 
 from __future__ import annotations
@@ -12,6 +17,13 @@ from dataclasses import asdict, dataclass, field
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
+
+# Postgres opcional — mismo patrón guarded-import de traces.py.
+try:
+    from pgvector_retrieval import _connection, is_pgvector_configured
+except Exception:
+    _connection = None
+    is_pgvector_configured = lambda: False  # noqa: E731
 
 REDACT_PATTERNS: list[tuple[re.Pattern[str], str]] = [
     (re.compile(r"sk-[A-Za-z0-9_\-]{20,}"), "[OPENAI_KEY]"),
@@ -70,20 +82,98 @@ def _logging_enabled() -> bool:
     )
 
 
+def _pg_enabled() -> bool:
+    """True si el dual-write a hv_decision_log debe intentarse."""
+    if os.getenv("HV_DECISION_LOG_PG", "true").lower() in ("0", "false", "no"):
+        return False
+    try:
+        return _connection is not None and is_pgvector_configured()
+    except Exception:
+        return False
+
+
+def _parse_ts(raw: str) -> datetime:
+    dt = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
+def _write_to_postgres(row: Dict[str, Any]) -> bool:
+    """INSERT fail-open a hv_decision_log. Nunca lanza al caller."""
+    try:
+        with _connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    INSERT INTO hv_decision_log
+                        (entry_id, ts, beta_id, channel, source, kb_route,
+                         gate_path, gate_code, top_score, confidence, payload)
+                    VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s::jsonb)
+                    ON CONFLICT (entry_id) DO NOTHING
+                    """,
+                    (
+                        row.get("entry_id"),
+                        _parse_ts(row["timestamp"]),
+                        row.get("beta_id"),
+                        row.get("channel"),
+                        row.get("source"),
+                        row.get("kb_route"),
+                        row.get("gate_path"),
+                        row.get("gate_code"),
+                        row.get("top_score"),
+                        row.get("confidence"),
+                        json.dumps(row, ensure_ascii=False),
+                    ),
+                )
+        return True
+    except Exception as e:
+        print(f"[decision-log] WARN: postgres insert failed (fail-open): {e}")
+        return False
+
+
+def _read_from_postgres(cutoff: datetime) -> Optional[List[Dict[str, Any]]]:
+    """SELECT por ventana. None = error (el caller cae a archivo)."""
+    try:
+        with _connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT payload FROM hv_decision_log WHERE ts >= %s ORDER BY ts ASC",
+                    (cutoff,),
+                )
+                rows: List[Dict[str, Any]] = []
+                for (payload,) in cur.fetchall():
+                    rows.append(payload if isinstance(payload, dict) else json.loads(payload))
+                return rows
+    except Exception as e:
+        print(f"[decision-log] WARN: postgres read failed, falling back to file: {e}")
+        return None
+
+
 def log_rag_decision(entry: RagDecisionEntry, path: Optional[Path] = None) -> Optional[str]:
-    """Append una fila JSONL. Fail-open: nunca lanza al caller."""
+    """Append JSONL + INSERT best-effort a Postgres. Fail-open: nunca lanza al caller.
+
+    `path` explícito = modo archivo puro (tests/tooling operan sobre un log concreto).
+    """
     if not _logging_enabled():
         return None
+    row = entry.to_json()
     log_path = path or _default_log_path()
+    file_ok = False
     try:
         log_path.parent.mkdir(parents=True, exist_ok=True)
-        line = json.dumps(entry.to_json(), ensure_ascii=False)
+        line = json.dumps(row, ensure_ascii=False)
         with log_path.open("a", encoding="utf-8") as f:
             f.write(line + "\n")
-        return entry.entry_id
+        file_ok = True
     except OSError as e:
         print(f"[decision-log] warn: could not write {log_path}: {e}")
-        return None
+
+    pg_ok = False
+    if path is None and _pg_enabled():
+        pg_ok = _write_to_postgres(row)
+
+    return entry.entry_id if (file_ok or pg_ok) else None
 
 
 def read_decisions(
@@ -91,10 +181,17 @@ def read_decisions(
     days: int = 7,
     path: Optional[Path] = None,
 ) -> List[Dict[str, Any]]:
+    cutoff = datetime.now(timezone.utc) - timedelta(days=days)
+
+    # Postgres primero (SSOT cross-máquina); archivo como bootstrap/fallback.
+    if path is None and _pg_enabled():
+        rows = _read_from_postgres(cutoff)
+        if rows:
+            return rows
+
     log_path = path or _default_log_path()
     if not log_path.exists():
         return []
-    cutoff = datetime.now(timezone.utc) - timedelta(days=days)
     rows: List[Dict[str, Any]] = []
     with log_path.open(encoding="utf-8") as f:
         for line in f:

--- a/rag-bot/migrations/004_hv_decision_log.down.sql
+++ b/rag-bot/migrations/004_hv_decision_log.down.sql
@@ -1,0 +1,7 @@
+BEGIN;
+
+DROP INDEX IF EXISTS idx_hv_decision_log_beta;
+DROP INDEX IF EXISTS idx_hv_decision_log_ts;
+DROP TABLE IF EXISTS hv_decision_log;
+
+COMMIT;

--- a/rag-bot/migrations/004_hv_decision_log.sql
+++ b/rag-bot/migrations/004_hv_decision_log.sql
@@ -1,0 +1,33 @@
+-- HV Decision Log — memoria episódica en SSOT (Guía: el registro de decisiones
+-- RAG vivía solo como JSONL en el volumen de UNA máquina Fly; no era consultable
+-- ni sobrevivía a un escalado multi-máquina). Esta tabla es el destino Postgres
+-- del dual-write de decision_log.py: el JSONL sigue como fallback local barato.
+--
+-- Siguiendo el patrón de 001/002/003: BEGIN/COMMIT + IF NOT EXISTS (idempotente),
+-- prefijo hv_* para aislamiento en el mismo Neon.
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS hv_decision_log (
+  id         BIGSERIAL PRIMARY KEY,
+  entry_id   TEXT NOT NULL UNIQUE,        -- uuid corto generado por RagDecisionEntry
+  ts         TIMESTAMPTZ NOT NULL,
+  beta_id    TEXT,
+  channel    TEXT,
+  source     TEXT,
+  kb_route   TEXT,
+  gate_path  TEXT,
+  gate_code  TEXT,
+  top_score  REAL,
+  confidence TEXT,
+  payload    JSONB NOT NULL DEFAULT '{}'::jsonb  -- fila completa (query ya redactada)
+);
+
+-- Lectura por ventana temporal (read_decisions / knowledge gaps semanal).
+CREATE INDEX IF NOT EXISTS idx_hv_decision_log_ts
+  ON hv_decision_log (ts DESC);
+-- Historial por beta.
+CREATE INDEX IF NOT EXISTS idx_hv_decision_log_beta
+  ON hv_decision_log (beta_id, ts DESC);
+
+COMMIT;

--- a/rag-bot/scripts/docker_entrypoint.sh
+++ b/rag-bot/scripts/docker_entrypoint.sh
@@ -20,6 +20,9 @@ if [ -n "${HV_DATABASE_URL:-}" ]; then
   echo "[entrypoint] apply migration 003 (hv_pending_actions — idempotencia C1)"
   python -c "from pgvector_retrieval import run_migration; run_migration('migrations/003_hv_pending_actions.sql')" || \
     echo "[entrypoint] WARN: migration 003 failed — proactive idempotency ledger unavailable"
+  echo "[entrypoint] apply migration 004 (hv_decision_log — memoria episódica SSOT)"
+  python -c "from pgvector_retrieval import run_migration; run_migration('migrations/004_hv_decision_log.sql')" || \
+    echo "[entrypoint] WARN: migration 004 failed — decision log queda solo en JSONL local"
 fi
 
 EMBEDDED_NEW=0

--- a/rag-bot/test_decision_log_pg.py
+++ b/rag-bot/test_decision_log_pg.py
@@ -1,0 +1,174 @@
+"""Tests del dual-write Postgres de decision_log (migración 004).
+
+Sin DB real: se monkeypatchea decision_log._connection con un fake que captura
+los execute(). Verifica el contrato fail-open y la política de lectura
+(Postgres primero, archivo como fallback; path explícito = archivo puro).
+"""
+from __future__ import annotations
+
+import json
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+import decision_log
+from decision_log import RagDecisionEntry, log_rag_decision, read_decisions
+
+
+@pytest.fixture(autouse=True)
+def _logging_on(monkeypatch):
+    # Otras suites del run combinado apagan el log vía os.environ sin cleanup
+    # (test_whatsapp_channel, test_c1_idempotency, …). Re-encender siempre aquí.
+    monkeypatch.setenv("HV_DECISION_LOG_ENABLED", "true")
+    monkeypatch.delenv("HV_DECISION_LOG_PG", raising=False)
+
+
+class FakeCursor:
+    def __init__(self, conn):
+        self.conn = conn
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+    def execute(self, sql, params=None):
+        self.conn.executed.append((sql.strip(), params))
+
+    def fetchall(self):
+        return self.conn.rows
+
+
+class FakeConn:
+    def __init__(self, rows=None):
+        self.executed = []
+        self.rows = rows or []
+
+    def cursor(self):
+        return FakeCursor(self)
+
+
+def _fake_connection_factory(conn):
+    @contextmanager
+    def _cm():
+        yield conn
+
+    return _cm
+
+
+def _entry(**kw) -> RagDecisionEntry:
+    defaults = dict(
+        query="¿precio de morpheus8?",
+        query_normalized="precio morpheus8",
+        kb_route="servicios",
+        gate_path="rag",
+    )
+    defaults.update(kw)
+    return RagDecisionEntry(**defaults)
+
+
+def _enable_pg(monkeypatch, conn):
+    monkeypatch.setattr(decision_log, "_connection", _fake_connection_factory(conn))
+    monkeypatch.setattr(decision_log, "is_pgvector_configured", lambda: True)
+
+
+def test_dual_write_inserts_to_postgres(tmp_path, monkeypatch):
+    monkeypatch.setenv("HV_DECISION_LOG_PATH", str(tmp_path / "log.jsonl"))
+    conn = FakeConn()
+    _enable_pg(monkeypatch, conn)
+
+    entry_id = log_rag_decision(_entry(beta_id="beta-x"))
+
+    assert entry_id
+    assert len(conn.executed) == 1
+    sql, params = conn.executed[0]
+    assert "hv_decision_log" in sql and "ON CONFLICT" in sql
+    assert params[0] == entry_id
+    assert params[2] == "beta-x"
+    payload = json.loads(params[-1])
+    assert payload["kb_route"] == "servicios"
+    # El archivo también se escribió (dual-write)
+    assert (tmp_path / "log.jsonl").exists()
+
+
+def test_pg_failure_is_fail_open(tmp_path, monkeypatch):
+    monkeypatch.setenv("HV_DECISION_LOG_PATH", str(tmp_path / "log.jsonl"))
+
+    @contextmanager
+    def _boom():
+        raise RuntimeError("db caída")
+        yield  # pragma: no cover
+
+    monkeypatch.setattr(decision_log, "_connection", _boom)
+    monkeypatch.setattr(decision_log, "is_pgvector_configured", lambda: True)
+
+    entry_id = log_rag_decision(_entry())
+
+    # La caída de Postgres no rompe ni pierde el registro local
+    assert entry_id
+    assert (tmp_path / "log.jsonl").read_text(encoding="utf-8").strip()
+
+
+def test_read_prefers_postgres(tmp_path, monkeypatch):
+    monkeypatch.setenv("HV_DECISION_LOG_PATH", str(tmp_path / "empty.jsonl"))
+    row = {
+        "entry_id": "abc123",
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "query": "[redacted]",
+        "kb_route": "longevity",
+    }
+    conn = FakeConn(rows=[(row,)])
+    _enable_pg(monkeypatch, conn)
+
+    rows = read_decisions(days=7)
+
+    assert rows == [row]
+    sql, params = conn.executed[0]
+    assert "FROM hv_decision_log" in sql
+
+
+def test_read_falls_back_to_file_when_pg_empty(tmp_path, monkeypatch):
+    log = tmp_path / "log.jsonl"
+    monkeypatch.setenv("HV_DECISION_LOG_PATH", str(log))
+    conn = FakeConn(rows=[])
+    _enable_pg(monkeypatch, conn)
+    log_rag_decision(_entry(), path=log)  # solo archivo
+
+    rows = read_decisions(days=7)
+
+    assert len(rows) == 1
+    assert rows[0]["kb_route"] == "servicios"
+
+
+def test_explicit_path_skips_postgres(tmp_path, monkeypatch):
+    conn = FakeConn()
+    _enable_pg(monkeypatch, conn)
+    log = tmp_path / "log.jsonl"
+
+    log_rag_decision(_entry(), path=log)
+    rows = read_decisions(days=7, path=log)
+
+    assert conn.executed == []  # ni write ni read tocaron la DB
+    assert len(rows) == 1
+
+
+def test_env_kill_switch(tmp_path, monkeypatch):
+    monkeypatch.setenv("HV_DECISION_LOG_PATH", str(tmp_path / "log.jsonl"))
+    monkeypatch.setenv("HV_DECISION_LOG_PG", "false")
+    conn = FakeConn()
+    _enable_pg(monkeypatch, conn)
+
+    log_rag_decision(_entry())
+
+    assert conn.executed == []
+
+
+if __name__ == "__main__":
+    import sys
+
+    import pytest
+
+    sys.exit(pytest.main([__file__, "-q"]))

--- a/rag-bot/test_observability.py
+++ b/rag-bot/test_observability.py
@@ -7,8 +7,16 @@ import subprocess
 import sys
 import tempfile
 import unittest
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from unittest import mock
+
+# Timestamp reciente para entradas sintéticas: una fecha fija caduca cuando
+# sale de la ventana days=N del detector (pasó con 2026-06-07 + days=30).
+def _recent_ts(minutes_ago: int = 0) -> str:
+    return (
+        datetime.now(timezone.utc) - timedelta(days=1, minutes=minutes_ago)
+    ).isoformat()
 
 from decision_log import log_rag_decision, read_decisions, redact_for_preview, RagDecisionEntry
 from knowledge_gap_detector import detect_knowledge_gaps, is_gap_row
@@ -53,7 +61,7 @@ class TestGapDetector(unittest.TestCase):
             path = Path(tmp) / "log.jsonl"
             for q in ("precio bitcoin", "precio del bitcoin hoy"):
                 entry = {
-                    "timestamp": "2026-06-07T12:00:00+00:00",
+                    "timestamp": _recent_ts(),
                     "query": q,
                     "query_normalized": strip_command_words(q),
                     "gate_path": "escalate",
@@ -175,7 +183,7 @@ class TestExpandGoldenFromLog(unittest.TestCase):
             )
             entries = [
                 {
-                    "timestamp": "2026-06-07T12:00:00+00:00",
+                    "timestamp": _recent_ts(minutes_ago=1),
                     "query": "botox entrecejo precio",
                     "query_normalized": "botox entrecejo precio",
                     "kb_route": "servicios",
@@ -185,7 +193,7 @@ class TestExpandGoldenFromLog(unittest.TestCase):
                     "top_service": "Botox (Toxina Botulínica Tipo A)",
                 },
                 {
-                    "timestamp": "2026-06-07T12:01:00+00:00",
+                    "timestamp": _recent_ts(),
                     "query": "precio botox entrecejo",
                     "query_normalized": "botox entrecejo precio",
                     "kb_route": "servicios",


### PR DESCRIPTION
Cierra el gap #1 de la evaluación del blueprint de memorias: la memoria episódica (`decision_log`) era el único stream que vivía solo en archivo local.

## Qué cambia
- **Migración 004**: tabla `hv_decision_log` (entry_id UNIQUE, ts, columnas indexadas + payload JSONB). El entrypoint la auto-aplica como 002/003.
- **Dual-write fail-open** (mismo patrón que `traces.py`): el JSONL local se mantiene; el INSERT a Postgres es best-effort y nunca rompe el flujo. Kill switch: `HV_DECISION_LOG_PG=false`.
- **Lectura PG-first**: `read_decisions` prefiere Postgres → el reporte semanal de knowledge gaps ve todas las máquinas, no solo el volumen local. `path` explícito fuerza modo archivo (tests y tooling intactos).
- **Fix colateral**: `test_observability` tenía timestamps fijos (2026-06-07) que caducaron de la ventana `days=30` — fallaba en local desde el 7-jul. Ahora dinámicos.

## Tests
105 pytest + observability + golden gates 25/25 + pgvector scaffold — todo verde local con el mismo set que corre CI. Nuevo `test_decision_log_pg.py` (6 tests, sin DB real: fake connection) cubre dual-write, fail-open, PG-first, fallback y kill switch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)