### PR TITLE
feat(newsletter): watchdog diario + teaser social automático

### DIFF
--- a/.github/workflows/newsletter-approval.yml
+++ b/.github/workflows/newsletter-approval.yml
@@ -156,12 +156,16 @@ jobs:
             echo "RESEND_API_KEY no configurado — envío omitido (sin error)."; exit 0
           fi
           python newsletter/send.py "${{ steps.parse.outputs.issue_path }}"
+          # Puente a redes: teaser lane:auto del número aprobado (sin claims).
+          # NO-FATAL: si falla, el envío del correo ya ocurrió y no se bloquea.
+          python newsletter/social_teaser.py "${{ steps.parse.outputs.issue_path }}" || \
+            echo "WARN: teaser social no generado (no bloquea el envío)"
           # PERSISTIR el registro de envío (sent_at/broadcast_id en approvals/NNN.json)
           # para que otra aprobación del mismo número NO reenvíe. send.py ya lo lee con
           # _already_sent; el bug era que el registro vivía solo en el runner efímero.
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add newsletter/approvals/ 2>/dev/null || true
+          git add newsletter/approvals/ newsletter/social/queue/ 2>/dev/null || true
           git commit -m "chore(newsletter): registro de envío $(basename "${{ steps.parse.outputs.issue_path }}" .md)" || true
           git push origin "${{ steps.branch.outputs.branch }}" || true
 

--- a/.github/workflows/pulso-watchdog.yml
+++ b/.github/workflows/pulso-watchdog.yml
@@ -1,0 +1,80 @@
+# Watchdog del pipeline Pulso — convierte fallas MUDAS en un correo al owner.
+# Nació del incidente 6-ago-2026: GitHub no asignó runner al draft del jueves
+# (Nº010 nunca se generó) y el Nº009 llevaba 9 días esperando aprobación — nadie
+# se enteró de ninguna de las dos cosas hasta revisar a mano semanas después.
+# Chequea diario: (a) ¿el último draft falló o no ha corrido en 8 días?
+# (b) ¿hay issues "Aprobar Pulso" abiertos >2 días? Si algo está mal → correo.
+# NO reintenta solo: workflow_dispatch vía GITHUB_TOKEN no dispara workflows
+# (regla anti-recursión de GitHub, ya la pagamos en newsletter-send) — avisa
+# con el link exacto para dar "Run workflow".
+name: Pulso watchdog
+
+on:
+  schedule:
+    - cron: '0 15 * * *'   # diario 15:00 UTC (9-10am CST)
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: read
+  actions: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Revisar pipeline y avisar si algo está atorado
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
+          NEWSLETTER_FROM: ${{ vars.NEWSLETTER_FROM }}
+          NEWSLETTER_APPROVAL_TO: ${{ vars.NEWSLETTER_APPROVAL_TO }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          FLAGS=""
+
+          # (a) Último run del draft: ¿falló, o el último éxito es de hace >8 días?
+          LAST=$(gh run list --repo "$REPO" --workflow newsletter-draft.yml --limit 1 \
+                 --json conclusion,createdAt,databaseId \
+                 --jq '.[0] | "\(.conclusion)|\(.createdAt)|\(.databaseId)"')
+          CONCL="${LAST%%|*}"; REST="${LAST#*|}"; WHEN="${REST%%|*}"; RUNID="${LAST##*|}"
+          AGE_DAYS=$(( ( $(date -u +%s) - $(date -u -d "$WHEN" +%s) ) / 86400 ))
+          if [ "$CONCL" != "success" ]; then
+            FLAGS="${FLAGS}<li>El último draft semanal <b>falló</b> (${WHEN}). Reintenta con \"Run workflow\": <a href='https://github.com/${REPO}/actions/workflows/newsletter-draft.yml'>newsletter-draft</a> · <a href='https://github.com/${REPO}/actions/runs/${RUNID}'>ver run</a></li>"
+          elif [ "$AGE_DAYS" -gt 8 ]; then
+            FLAGS="${FLAGS}<li>El draft semanal <b>no corre desde hace ${AGE_DAYS} días</b> (cron jueves — ¿repo inactivo >60 días o workflow deshabilitado?). <a href='https://github.com/${REPO}/actions/workflows/newsletter-draft.yml'>Revisar</a></li>"
+          fi
+
+          # (b) Aprobaciones atoradas: issues "Aprobar Pulso" abiertos >2 días.
+          NOW=$(date -u +%s)
+          while IFS=$'\t' read -r NUM TITLE CREATED; do
+            [ -z "${NUM:-}" ] && continue
+            AGE=$(( ( NOW - $(date -u -d "$CREATED" +%s) ) / 86400 ))
+            if [ "$AGE" -ge 2 ]; then
+              FLAGS="${FLAGS}<li><b>${TITLE}</b> lleva <b>${AGE} días</b> esperando tu OK → <a href='https://github.com/${REPO}/issues/${NUM}'>responder al issue</a> (o botón del correo original)</li>"
+            fi
+          done < <(gh issue list --repo "$REPO" --state open --search '"Aprobar Pulso" in:title' \
+                   --json number,title,createdAt \
+                   --jq '.[] | [.number, .title, .createdAt] | @tsv')
+
+          if [ -z "$FLAGS" ]; then
+            echo "✅ Pipeline Pulso sano — sin avisos."
+            exit 0
+          fi
+
+          echo "⚠️ Flags detectados:"
+          echo "$FLAGS" | sed 's/<[^>]*>//g'
+
+          if [ -z "${RESEND_API_KEY:-}" ] || [ -z "${NEWSLETTER_APPROVAL_TO:-}" ]; then
+            echo "Sin RESEND_API_KEY/NEWSLETTER_APPROVAL_TO — aviso solo en log."
+            exit 0
+          fi
+
+          BODY="<p>El watchdog diario de Pulso Vigente encontró esto:</p><ul>${FLAGS}</ul><p style='color:#888'>Este aviso se repite a diario mientras el problema siga. — pulso-watchdog</p>"
+          PAYLOAD=$(python3 -c "import json,os,sys; print(json.dumps({'from': os.environ['NEWSLETTER_FROM'], 'to': [os.environ['NEWSLETTER_APPROVAL_TO']], 'subject': '⚠️ Pulso Vigente necesita tu atención', 'html': sys.argv[1]}))" "$BODY")
+          curl -fsS -X POST https://api.resend.com/emails \
+            -H "Authorization: Bearer ${RESEND_API_KEY}" \
+            -H "Content-Type: application/json" \
+            -d "$PAYLOAD" > /dev/null
+          echo "📧 Aviso enviado a ${NEWSLETTER_APPROVAL_TO}"

--- a/newsletter/social_teaser.py
+++ b/newsletter/social_teaser.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""
+Auto-encola un teaser lane:auto al aprobar un Pulso.
+
+Puente Pulso → redes SIN pasos extra del owner: el anuncio del número (sin
+claims de salud — solo "ya salió") entra al carril AUTO y social-auto lo
+publica en su siguiente corrida. El paquete social con ciencia (social/NNN/)
+sigue siendo carril GATED. El claim-guard de publish.py aplica igual al
+teaser: si un subject algún día trae lenguaje de claim, se frena solo.
+
+Uso: python newsletter/social_teaser.py newsletter/issues/2026-07-009.md
+Idempotente: si el teaser del número ya existe, no hace nada.
+"""
+from __future__ import annotations
+
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import yaml
+
+QUEUE_DIR = Path(__file__).resolve().parent / "social" / "queue"
+
+
+def build_teaser(issue_path: Path) -> Path | None:
+    raw = issue_path.read_text(encoding="utf-8")
+    m = re.match(r"^---\n(.*?)\n---", raw, re.S)
+    if not m:
+        print(f"[teaser] sin frontmatter en {issue_path} — omitido")
+        return None
+    meta = yaml.safe_load(m.group(1)) or {}
+    numero = str(meta.get("numero", "")).strip()
+    subject = str(meta.get("subject", "")).strip()
+    if not numero or not subject:
+        print("[teaser] frontmatter sin numero/subject — omitido")
+        return None
+
+    # "Pulso Vigente Nº008 — Título" → "Título"
+    title = re.sub(r"^Pulso Vigente\s+N[º°]\s*\d+\s*[—-]\s*", "", subject).strip()
+    today = datetime.now(timezone.utc).date().isoformat()
+    dest = QUEUE_DIR / f"{today}-pulso-{numero}-teaser.md"
+    if dest.exists():
+        print(f"[teaser] ya existe {dest.name} — idempotente, nada que hacer")
+        return dest
+
+    body = f"""---
+lane: auto
+platforms: [instagram, facebook, x]
+date: {today}
+image_url: ""
+---
+📬 Ya salió Pulso Vigente Nº{numero}
+
+{title}
+
+Ciencia de longevidad verificada — papers reales, cero humo — cada semana en tu correo.
+
+#HombreVigente #longevidad #PulsoVigente
+"""
+    QUEUE_DIR.mkdir(parents=True, exist_ok=True)
+    dest.write_text(body, encoding="utf-8")
+    print(f"[teaser] encolado {dest.name} (lane:auto — sale en la próxima corrida social)")
+    return dest
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        sys.exit("Uso: social_teaser.py <ruta-issue.md>")
+    build_teaser(Path(sys.argv[1]))


### PR DESCRIPTION
Dos fallas mudas detectadas hoy: el draft del 6-ago murió sin runner (infra de GitHub, no nuestro código) y el Nº009 lleva 9 días esperando aprobación sin que nada avisara.

## Watchdog (`pulso-watchdog.yml`)
Diario 15:00 UTC: (a) ¿último draft falló o lleva >8 días sin correr? (b) ¿issues «Aprobar Pulso» abiertos ≥2 días? → correo a `NEWSLETTER_APPROVAL_TO` con links accionables. Se repite a diario mientras el problema siga. No auto-reintenta: `workflow_dispatch` vía `GITHUB_TOKEN` no dispara workflows (anti-recursión, ya la pagamos en newsletter-send) — el correo trae el link de «Run workflow».

## Puente Pulso → redes (`social_teaser.py`)
Al aprobar un número, se auto-encola un teaser `lane:auto` sin claims de salud → `social-auto` lo publica en su siguiente corrida. El paquete social con ciencia sigue GATED. Claim-guard aplica igual. No-fatal: si falla, el envío del correo no se bloquea. Probado local (generación + idempotencia).

🤖 Generated with [Claude Code](https://claude.com/claude-code)