### PR TITLE
fix(newsletter): previews/avisos a múltiples inboxes + TTL botón 7 días

### DIFF
--- a/.github/workflows/pulso-watchdog.yml
+++ b/.github/workflows/pulso-watchdog.yml
@@ -72,7 +72,7 @@ jobs:
           fi
 
           BODY="<p>El watchdog diario de Pulso Vigente encontró esto:</p><ul>${FLAGS}</ul><p style='color:#888'>Este aviso se repite a diario mientras el problema siga. — pulso-watchdog</p>"
-          PAYLOAD=$(python3 -c "import json,os,sys; print(json.dumps({'from': os.environ['NEWSLETTER_FROM'], 'to': [os.environ['NEWSLETTER_APPROVAL_TO']], 'subject': '⚠️ Pulso Vigente necesita tu atención', 'html': sys.argv[1]}))" "$BODY")
+          PAYLOAD=$(python3 -c "import json,os,sys; to=[t.strip() for t in os.environ['NEWSLETTER_APPROVAL_TO'].split(',') if t.strip()]; print(json.dumps({'from': os.environ['NEWSLETTER_FROM'], 'to': to, 'subject': '⚠️ Pulso Vigente necesita tu atención', 'html': sys.argv[1]}))" "$BODY")
           curl -fsS -X POST https://api.resend.com/emails \
             -H "Authorization: Bearer ${RESEND_API_KEY}" \
             -H "Content-Type: application/json" \

--- a/newsletter/approval.py
+++ b/newsletter/approval.py
@@ -126,10 +126,15 @@ def send_preview(path: Path) -> None:
         headers={"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"},
         json={
             "from": sender,
-            "to": [to],
+            # NEWSLETTER_APPROVAL_TO acepta varios destinos separados por coma
+            # (ej. contacto@ + inbox personal) — un solo buzón resultó ser
+            # punto único de falla (previews del 009 perdidos, ago-2026).
+            "to": [t.strip() for t in to.split(",") if t.strip()],
             "subject": subject,
             "html": html,
-            "reply_to": os.environ.get("NEWSLETTER_APPROVAL_REPLY_TO", to),
+            "reply_to": os.environ.get(
+                "NEWSLETTER_APPROVAL_REPLY_TO", to.split(",")[0].strip()
+            ),
         },
         timeout=30,
     )

--- a/newsletter/approval_token.py
+++ b/newsletter/approval_token.py
@@ -15,7 +15,9 @@ def _secret() -> str:
     return s
 
 
-def make_token(issue_path: str, action: str, ttl_hours: int = 96) -> str:
+def make_token(issue_path: str, action: str, ttl_hours: int = 168) -> str:
+    # 168h = 1 semana: con TTL de 96h, un preview que pasa el fin de semana en
+    # spam llega con el botón muerto ("no se pudo aprobar", Nº009 ago-2026).
     exp = int(time.time()) + ttl_hours * 3600
     sig = hmac.new(
         _secret().encode(),

--- a/newsletter/social/queue/2026-08-09-pulso-009-teaser.md
+++ b/newsletter/social/queue/2026-08-09-pulso-009-teaser.md
@@ -1,0 +1,13 @@
+---
+lane: auto
+platforms: [instagram, facebook, x]
+date: 2026-08-09
+image_url: ""
+---
+📬 Ya salió Pulso Vigente Nº009
+
+Tu reloj epigenético responde a lo que comes
+
+Ciencia de longevidad verificada — papers reales, cero humo — cada semana en tu correo.
+
+#HombreVigente #longevidad #PulsoVigente


### PR DESCRIPTION
- NEWSLETTER_APPROVAL_TO acepta lista separada por comas (un solo buzón
  fue punto único de falla: el preview del 009 se perdió 10 días).
- TTL del botón de aprobación 96h → 168h (un email rezagado llegaba con
  el botón muerto: 'no se pudo aprobar').
- Teaser social del 009 encolado a mano (la rama del borrador era
  anterior al script de teaser).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
