### PR TITLE
docs(newsletter): tablas Editorial bridge retro para Pulsos 005-010

### DIFF
--- a/newsletter/issues/2026-07-005.md
+++ b/newsletter/issues/2026-07-005.md
@@ -103,3 +103,16 @@ El número en tu panel básico no cuenta la historia completa — ni en lípidos
 ---
 
 > **Disclaimer:** Pulso Vigente es contenido editorial de optimización e información científica. No constituye consejo médico, diagnóstico ni prescripción. Los estudios citados se referencian con su PMID/DOI original; no se han inventado cifras, autores ni resultados. Consulta a tu médico antes de modificar cualquier protocolo de salud. Nivel de evidencia indicado por edición; preclínico ≠ aplicable en humanos.
+
+---
+
+## Editorial bridge (retro ago-2026 — verificar antes de merge)
+
+| bloque | topic_ssot | monografía | pmid / doi | nivel E | bridge |
+|--------|------------|------------|------------|---------|--------|
+| Accionable | lipidos_apob | 25_biomarcadores_panel_optimizacion.md | s00394-026-04027-2 | E3 | A |
+| Frontera | autofagia_espermidina | 04_autofagia_spermidina.md | j.tice.2026.103742 | E3 | C |
+| AI × Longevity | descubrimiento_farmacos_ia | 06_epigenetica_relojes_biologicos.md | cells15121123 | E3 | A |
+| Contexto / Voz | hallmarks_envejecimiento | 01_hallmarks_envejecimiento.md | s11357-026-02362-0 | E3 | C |
+
+- **A** = patch a monografía SSOT · **C** = solo Pulso/redes

--- a/newsletter/issues/2026-07-006.md
+++ b/newsletter/issues/2026-07-006.md
@@ -98,3 +98,16 @@ Este número conecta cuatro puntos que en la medicina convencional raramente se 
 *Pulso Vigente es una publicación de divulgación científica de Hombre Vigente™. El contenido tiene fines informativos y educativos exclusivamente. Ningún texto de esta newsletter constituye consejo médico, diagnóstico, prescripción ni recomendación terapéutica. Consulta siempre a un profesional de salud calificado antes de modificar cualquier aspecto de tu protocolo de salud. Los estudios citados corresponden a los candidatos verificados asignados editorialmente; no se han inventado PMIDs, DOIs, cifras ni afirmaciones no contenidas en las fuentes originales. Los niveles de evidencia son orientativos y no reemplazan la evaluación clínica individual.*
 
 *© 2026 Hombre Vigente™ · México · Todos los derechos reservados.*
+
+---
+
+## Editorial bridge (retro ago-2026 — verificar antes de merge)
+
+| bloque | topic_ssot | monografía | pmid / doi | nivel E | bridge |
+|--------|------------|------------|------------|---------|--------|
+| Accionable | lipidos_apob | 25_biomarcadores_panel_optimizacion.md | jamacardio.2026.1208 | E3 | A |
+| Frontera | autofagia_espermidina | 04_autofagia_spermidina.md | acel.70593 | E3 | C |
+| AI × Longevity | diseno_proteinas | 01_hallmarks_envejecimiento.md | acel.70607 | E3 | A |
+| Contexto / Voz | hallmarks_envejecimiento | 01_hallmarks_envejecimiento.md | s11357-026-02373-x | E3 | C |
+
+- **A** = patch a monografía SSOT · **C** = solo Pulso/redes

--- a/newsletter/issues/2026-07-007.md
+++ b/newsletter/issues/2026-07-007.md
@@ -111,3 +111,16 @@ Esta edición conecta cuatro vectores que en HV tratamos como sistema, no como s
 ---
 
 > **Disclaimer:** Pulso Vigente es contenido editorial de optimización e información científica. No constituye consejo médico, diagnóstico ni prescripción. Los estudios citados se referencian por PMID/DOI verificados; no se inventan cifras, autores ni resultados. Consulta a tu médico antes de modificar cualquier protocolo de salud. Hombre Vigente™ no tiene relación comercial con los autores ni journals citados en esta edición.
+
+---
+
+## Editorial bridge (retro ago-2026 — verificar antes de merge)
+
+| bloque | topic_ssot | monografía | pmid / doi | nivel E | bridge |
+|--------|------------|------------|------------|---------|--------|
+| Accionable | lipidos_apob | 25_biomarcadores_panel_optimizacion.md | j.semerg.2026.102799 | E3 | A |
+| Frontera | epigenetica_relojes_reprogramacion | 07_reprogramacion_celular.md | s00018-026-06317-8 | E3 | C |
+| AI × Longevity | modelos_fundacionales_biologia | 01_hallmarks_envejecimiento.md | science.adz4351 | E3 | A |
+| Contexto / Voz | hallmarks_envejecimiento | 01_hallmarks_envejecimiento.md | s11357-026-02420-7 | E3 | C |
+
+- **A** = patch a monografía SSOT · **C** = solo Pulso/redes

--- a/newsletter/issues/2026-07-008.md
+++ b/newsletter/issues/2026-07-008.md
@@ -91,3 +91,16 @@ El paper posiciona a PERK como una diana terapéutica de doble filo: inhibirla s
 ---
 
 > **Disclaimer:** Pulso Vigente es un newsletter de divulgación científica con fines informativos. Ningún contenido constituye consejo médico, diagnóstico ni recomendación terapéutica. Consulta siempre a un profesional de salud calificado antes de modificar cualquier protocolo. Los estudios citados se referencian con PMID/DOI verificables; el lector puede consultarlos directamente en PubMed o Europe PMC. Hombre Vigente™ no tiene relación comercial con ninguno de los fármacos, compuestos o empresas mencionados en esta edición.
+
+---
+
+## Editorial bridge (retro ago-2026 — verificar antes de merge)
+
+| bloque | topic_ssot | monografía | pmid / doi | nivel E | bridge |
+|--------|------------|------------|------------|---------|--------|
+| Accionable | lipidos_apob | 25_biomarcadores_panel_optimizacion.md | s00125-026-06810-6 | E3 | A |
+| Frontera | autofagia_espermidina | 04_autofagia_spermidina.md | j.celrep.2026.117703 | E3 | C |
+| AI × Longevity | modelos_fundacionales_biologia | 01_hallmarks_envejecimiento.md | science.adz4351 | E3 | A |
+| Contexto / Voz | inflammaging | 02_inflammaging.md | s11357-026-02430-5 | E3 | C |
+
+- **A** = patch a monografía SSOT · **C** = solo Pulso/redes

--- a/newsletter/issues/2026-07-009.md
+++ b/newsletter/issues/2026-07-009.md
@@ -90,3 +90,16 @@ La longevidad gestionada no es una intervención; es una arquitectura de informa
 ---
 
 > **Disclaimer:** Pulso Vigente es una publicación de divulgación científica de Hombre Vigente™. El contenido tiene fines informativos y educativos exclusivamente. Ningún texto de esta newsletter constituye consejo médico, diagnóstico, prescripción ni recomendación terapéutica. Consulta siempre a un profesional de salud calificado antes de modificar cualquier aspecto de tu protocolo de salud. Los estudios citados se referencian con su PMID/DOI verificable; el lector es invitado a consultarlos directamente. Las menciones a moléculas, intervenciones o biomarcadores describen hallazgos de investigación, no productos ni tratamientos aprobados para los usos descritos salvo indicación explícita.
+
+---
+
+## Editorial bridge (retro ago-2026 — verificar antes de merge)
+
+| bloque | topic_ssot | monografía | pmid / doi | nivel E | bridge |
+|--------|------------|------------|------------|---------|--------|
+| Accionable | lipidos_apob | 25_biomarcadores_panel_optimizacion.md | j.autrev.2026.104153 | E3 | A |
+| Frontera | autofagia_espermidina | 04_autofagia_spermidina.md | j.celrep.2026.117703 | E3 | C |
+| AI × Longevity | diseno_proteinas | 01_hallmarks_envejecimiento.md | s12602-026-11131-6 | E3 | A |
+| Contexto / Voz | hallmarks_envejecimiento | 01_hallmarks_envejecimiento.md | s11357-026-02443-0 | E3 | C |
+
+- **A** = patch a monografía SSOT · **C** = solo Pulso/redes

--- a/newsletter/issues/2026-08-010.md
+++ b/newsletter/issues/2026-08-010.md
@@ -101,3 +101,16 @@ El número 010 no es sobre intervenciones aisladas — es sobre **sistemas que s
 
 ---
 *Pulso Vigente Nº010 · 2026-08-09 · Hombre Vigente™ · longevidad gestionada*
+
+---
+
+## Editorial bridge (retro ago-2026 — verificar antes de merge)
+
+| bloque | topic_ssot | monografía | pmid / doi | nivel E | bridge |
+|--------|------------|------------|------------|---------|--------|
+| Accionable | lipidos_apob | 25_biomarcadores_panel_optimizacion.md | j.jacasi.2026.05.033 | E3 | A |
+| Frontera | autofagia_espermidina | 04_autofagia_spermidina.md | acel.70644 | E3 | C |
+| AI × Longevity | relojes_envejecimiento_ml | 06_epigenetica_relojes_biologicos.md | s13059-026-04188-7 | E3 | A |
+| Contexto / Voz | hallmarks_envejecimiento | 01_hallmarks_envejecimiento.md | s11357-026-02427-0 | E2 | C |
+
+- **A** = patch a monografía SSOT · **C** = solo Pulso/redes


### PR DESCRIPTION
Los números auto-redactados salieron sin la tabla que parsea
bridge_export (el LLM la renombraba a 'Tabla Editorial — Bridge') —
su ciencia nunca llegó al corpus RAG. Tablas reconstruidas con la
lógica real del código (topics de candidates-*.md por PMID +
evidence_level/bridge_type/TOPIC_MONOGRAPHY importados): 12 entradas
tipo A en 6 números. El merge dispara el bridge → PR de patches a
monografías para revisión editorial.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
